### PR TITLE
Fix parsing, in-cell Delete, and external-editor elevation (v1.3.1 / v1.0.1)

### DIFF
--- a/HostsFileEditor.Core.Tests/HostsEntryTests.cs
+++ b/HostsFileEditor.Core.Tests/HostsEntryTests.cs
@@ -135,6 +135,39 @@ public class HostsEntryTests
     }
 
     [TestMethod]
+    public void Parse_LeadingWhitespace_DisabledEntry()
+    {
+        // Issue #22: a space before the '#' must not break parsing — the line is still a
+        // disabled host entry, not a plain comment.
+        var entry = new HostsEntry(" # 127.0.0.1  localhost");
+        entry.Valid.ShouldBeTrue();
+        entry.Enabled.ShouldBeFalse();
+        entry.IpAddress.ShouldBe("127.0.0.1");
+        entry.HostNames.ShouldBe("localhost");
+    }
+
+    [TestMethod]
+    public void Parse_LeadingWhitespace_EnabledEntry()
+    {
+        // Leading whitespace before an enabled entry likewise parses normally.
+        var entry = new HostsEntry("   127.0.0.1 localhost");
+        entry.Valid.ShouldBeTrue();
+        entry.Enabled.ShouldBeTrue();
+        entry.IpAddress.ShouldBe("127.0.0.1");
+        entry.HostNames.ShouldBe("localhost");
+    }
+
+    [TestMethod]
+    public void Parse_LeadingTab_DisabledEntry()
+    {
+        var entry = new HostsEntry("\t# 10.0.0.1 example.com");
+        entry.Valid.ShouldBeTrue();
+        entry.Enabled.ShouldBeFalse();
+        entry.IpAddress.ShouldBe("10.0.0.1");
+        entry.HostNames.ShouldBe("example.com");
+    }
+
+    [TestMethod]
     public void Parse_DisabledWithAfterComment()
     {
         var entry = new HostsEntry("# 127.0.0.1 localhost # note");

--- a/HostsFileEditor.Core/HostsEntry.cs
+++ b/HostsFileEditor.Core/HostsEntry.cs
@@ -395,6 +395,11 @@ public partial class HostsEntry : INotifyPropertyChanged, IDataErrorInfo
     // blank one, so trailing junk (e.g. a port after the hostname) was silently dropped and
     // an unmatched remainder still "parsed". Lines matching nothing are preserved as comments
     // by the constructor.
-    [GeneratedRegex(@"^((?<disabled>#+)?\s*(?<ipaddress>[^\s]+)\s+(?<hostname>([\w-]+\.)*([\w-]+)((\s)+([\w-]+\.)*([\w-]+))*)\s*(#+(?<aftercomment>.*))?)$|^(\s*#+\s?(?<comment>.*))$|^(?<blank>\s*)$", RegexOptions.Compiled)]
+    //
+    // The entry alternative leads with \s* so a line with leading whitespace before the
+    // optional '#' still parses as an entry (issue #22). Without it, \s* consumed the leading
+    // space and '#' was captured as the ipaddress, demoting a valid disabled entry (e.g.
+    // " # 1.2.3.4 host") to a plain comment.
+    [GeneratedRegex(@"^(\s*(?<disabled>#+)?\s*(?<ipaddress>[^\s]+)\s+(?<hostname>([\w-]+\.)*([\w-]+)((\s)+([\w-]+\.)*([\w-]+))*)\s*(#+(?<aftercomment>.*))?)$|^(\s*#+\s?(?<comment>.*))$|^(?<blank>\s*)$", RegexOptions.Compiled)]
     private static partial Regex ValidHostsRegex();
 }

--- a/HostsFileEditor.Core/Utilities/FileOpener.cs
+++ b/HostsFileEditor.Core/Utilities/FileOpener.cs
@@ -1,10 +1,14 @@
 using Microsoft.Win32;
+using System.ComponentModel;
 using System.Diagnostics;
 
 namespace HostsFileEditor.Utilities;
 
 public static class FileOpener
 {
+    /// <summary>ERROR_CANCELLED — returned by ShellExecute when the user declines the UAC prompt.</summary>
+    private const int ErrorCancelled = 1223;
+
     public static void OpenTextFile(string path)
     {
         if (!TryGetRegisteredApplication(".txt", out var application) || application == null)
@@ -12,7 +16,26 @@ public static class FileOpener
             application = "notepad.exe";
         }
 
-        Process.Start(application, path);
+        // The hosts file is admin-owned and this app runs as a standard user (asInvoker), so an
+        // editor launched with the default token cannot save edits to it. Launch the editor
+        // elevated via the "runas" verb (a UAC prompt) so it can actually write the file. A
+        // declined prompt (ERROR_CANCELLED) just means "don't open" — swallow it, don't crash.
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = application,
+            Arguments = $"\"{path}\"",
+            UseShellExecute = true,
+            Verb = "runas",
+        };
+
+        try
+        {
+            Process.Start(startInfo);
+        }
+        catch (Win32Exception ex) when (ex.NativeErrorCode == ErrorCancelled)
+        {
+            // User declined the elevation prompt; nothing to open.
+        }
     }
 
     private static bool TryGetRegisteredApplication(string extension, out string? registeredApp)

--- a/HostsFileEditor.WinForm/HostsFileEditor.WinForm.csproj
+++ b/HostsFileEditor.WinForm/HostsFileEditor.WinForm.csproj
@@ -14,7 +14,7 @@
     <!-- Single version source for this app: drives AssemblyVersion, FileVersion, the exe's
          ProductVersion resource, and (stamped in Directory.Build.targets) the MSIX manifest
          Identity/@Version. ProductVersion is not an SDK-recognized property and was ignored. -->
-    <Version>1.3.0.0</Version>
+    <Version>1.3.1.0</Version>
     <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
     <!-- Native AOT isn't working yet with WinForms, specifically Binding is explicitly not supported throwing NotSupportedException -->
     <!--<PublishAot>true</PublishAot>-->

--- a/HostsFileEditor.WinForm/MainForm.cs
+++ b/HostsFileEditor.WinForm/MainForm.cs
@@ -265,6 +265,23 @@ internal sealed partial class MainForm : Form
     /// </param>
     private void OnDeleteClick(object sender, EventArgs e)
     {
+        // HACK: forward Delete to the in-cell text editor when editing a cell's text with no
+        // full row selected, so it removes the character in front of the cursor instead of
+        // wiping the cell (issue #36). Mirrors the Ctrl+C/X/V forwarding in OnCopy/Cut/PasteClick;
+        // both menuDelete and menuContextDelete carry the Del shortcut, so clear both to avoid
+        // re-triggering this handler while the synthetic keystroke is dispatched.
+        if (dataGridViewHostsEntries.IsCurrentCellInEditMode
+            && dataGridViewHostsEntries.SelectedRows.Count == 0)
+        {
+            var keys = menuDelete.ShortcutKeys;
+            menuDelete.ShortcutKeys = Keys.None;
+            menuContextDelete.ShortcutKeys = Keys.None;
+            SendKeys.SendWait("{DEL}");
+            menuDelete.ShortcutKeys = keys;
+            menuContextDelete.ShortcutKeys = keys;
+            return;
+        }
+
         if (dataGridViewHostsEntries.SelectedRows.Count > 0)
         {
             HostsFile.Instance.Entries.Remove(

--- a/HostsFileEditor.WinUI/HostsFileEditor.WinUI.csproj
+++ b/HostsFileEditor.WinUI/HostsFileEditor.WinUI.csproj
@@ -7,7 +7,7 @@
     <!-- Single version source for this app (the modern UI ships as its own version stream,
          separate from classic). Drives AssemblyVersion/FileVersion/ProductVersion and, stamped
          in Directory.Build.targets, the MSIX manifest Identity/@Version. -->
-    <Version>1.0.0.0</Version>
+    <Version>1.0.1.0</Version>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platform Condition="'$(Platform)' == ''">x64</Platform>
     <Platforms>x64;arm64</Platforms>


### PR DESCRIPTION
Post-v1.3.0 bug-fix patch. Ships as **classic 1.3.1** and **modern 1.0.1**.

## Fixes

- **Leading-whitespace parsing (#22)** — a hosts line with whitespace before the `#` (e.g. ` # 127.0.0.1 host`) was demoted to a plain comment instead of parsing as a disabled entry. The entry regex alternative now leads with `\s*`, matching the comment/blank alternatives. Adds leading-whitespace parse tests.
- **Delete key while editing a cell (#36)** — pressing Delete while editing a cell's text wiped the whole cell instead of deleting the character in front of the cursor. `OnDeleteClick` now forwards Delete to the in-cell editor when a cell is in edit mode with no full row selected, mirroring the existing Ctrl+C/X/V forwarding. Row-level Delete is unchanged.
- **External editor could not save the hosts file (#49)** — since v1.3.0 the app runs as a standard user, so *Open Text Editor* launched the editor non-elevated and it could not write the admin-owned hosts file. It now launches elevated via the `runas` verb (a declined UAC prompt is swallowed, not crashed). Shared Core change, so it fixes both editions.
- **Version bump** — classic 1.3.0.0 → 1.3.1.0, modern 1.0.0.0 → 1.0.1.0.

## Note on #23

While implementing this I confirmed **#23 (in-cell Ctrl+C/V)** is already handled in v1.3.0 — the copy/cut/paste handlers forward those keys to the in-cell editor. No code change needed here; it can be closed as already-fixed.

## Testing

- Core: 91 tests pass (3 new leading-whitespace tests); classic + modern build clean (warnings-as-errors).
- Manually verified on a classic build: #22 (disabled entry with a leading space), #36 (Delete removes a character while editing; header-row Delete still deletes the row), #49 (Open Text Editor prompts for UAC and the elevated editor saves the file; declining is a no-op).

Closes #22
Closes #36
Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)