### PR TITLE
Recover from a corrupt user.config instead of crashing at startup (#37)

### DIFF
--- a/HostsFileEditor.WinForm/MainForm.cs
+++ b/HostsFileEditor.WinForm/MainForm.cs
@@ -2,6 +2,7 @@ using Equin.ApplicationFramework;
 using HostsFileEditor.Extensions;
 using HostsFileEditor.Properties;
 using HostsFileEditor.Utilities;
+using System.Configuration;
 using System.Text;
 
 namespace HostsFileEditor;
@@ -1022,7 +1023,20 @@ internal sealed partial class MainForm : Form
     /// </summary>
     private void LoadSettings()
     {
-        var settings = Settings.Default;
+        Settings settings;
+        try
+        {
+            settings = Settings.Default;
+
+            // The first property access loads user.config; a corrupt file throws here. Recover
+            // and start with defaults rather than failing to launch (issue #37).
+            _ = settings.AutoPingIPAddresses;
+        }
+        catch (ConfigurationErrorsException ex)
+        {
+            ResetCorruptUserConfig(ex);
+            return;
+        }
 
         HostsEntry.AutoPingIPAddress = settings.AutoPingIPAddresses;
         HostsFile.RemoveDefaultText = settings.RemoveDefaultText;
@@ -1059,29 +1073,73 @@ internal sealed partial class MainForm : Form
     /// </summary>
     private void SaveSettings()
     {
-        var settings = Settings.Default;
-
-        settings.AutoPingIPAddresses = HostsEntry.AutoPingIPAddress;
-        settings.RemoveDefaultText = HostsFile.RemoveDefaultText;
-        settings.WindowLocation = Location;
-        settings.ArchiveVisible = menuViewArchive.Checked;
-
-        // Save size for normal window, don't save anything for minimized
-        // since that's probably not what the user wants next time
-        // they open
-        if (WindowState == FormWindowState.Normal)
+        try
         {
-            settings.WindowSize = Size;
-            settings.WindowState = WindowState;
+            var settings = Settings.Default;
+
+            settings.AutoPingIPAddresses = HostsEntry.AutoPingIPAddress;
+            settings.RemoveDefaultText = HostsFile.RemoveDefaultText;
+            settings.WindowLocation = Location;
+            settings.ArchiveVisible = menuViewArchive.Checked;
+
+            // Save size for normal window, don't save anything for minimized
+            // since that's probably not what the user wants next time
+            // they open
+            if (WindowState == FormWindowState.Normal)
+            {
+                settings.WindowSize = Size;
+                settings.WindowState = WindowState;
+            }
+            else if (WindowState == FormWindowState.Maximized)
+            {
+                settings.WindowState = WindowState;
+            }
+
+            settings.SplitterWidth = splitContainer.SplitterDistance;
+
+            settings.Save();
         }
-        else if (WindowState == FormWindowState.Maximized)
+        catch (ConfigurationErrorsException)
         {
-            settings.WindowState = WindowState;
+            // Persisting settings must never crash the app (e.g. a corrupt or locked user.config
+            // on exit/shutdown). Losing window bounds/preferences is acceptable; failing to close
+            // is not (issue #37).
+        }
+    }
+
+    /// <summary>
+    /// Recovers from a corrupt user settings file by deleting it and reloading defaults, so a bad
+    /// <c>user.config</c> cannot prevent the app from starting (issue #37).
+    /// </summary>
+    private static void ResetCorruptUserConfig(ConfigurationErrorsException ex)
+    {
+        // The offending path is on the exception (sometimes only on the inner one).
+        var badFile = (ex.InnerException as ConfigurationErrorsException)?.Filename;
+        if (string.IsNullOrEmpty(badFile))
+        {
+            badFile = ex.Filename;
         }
 
-        settings.SplitterWidth = splitContainer.SplitterDistance;
+        try
+        {
+            if (!string.IsNullOrEmpty(badFile) && File.Exists(badFile))
+            {
+                File.Delete(badFile);
+            }
 
-        settings.Save();
+            // Drop the faulted in-memory state so the rest of the session reads clean defaults.
+            Settings.Default.Reload();
+        }
+        catch (IOException)
+        {
+            // Best effort — fall back to in-memory defaults for this session.
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+        catch (ConfigurationErrorsException)
+        {
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Hardens the classic app against a missing/corrupt `user.config` so it cannot prevent startup (issue #37).

## Change

The classic edition reads window bounds and preferences via `Settings.Default`. A corrupt `user.config` throws `ConfigurationErrorsException` on first property access, so the app failed to launch. This PR:

- Guards `LoadSettings` — on a corrupt config it recovers and starts with defaults instead of crashing.
- Guards `SaveSettings` — a corrupt/locked config on exit can no longer crash shutdown.
- Adds `ResetCorruptUserConfig` — deletes the bad file (path taken from the exception) and reloads defaults, best-effort.

This mirrors the corrupt-JSON handling the **modern** (WinUI) edition already has, bringing the classic app in line. Classic-only change; folds into the pending v1.3.1 (no version bump).

Note on the original report: the "settings ignored" part of #37 was editing the *app* config vs the user-scoped `user.config` (by design, not a bug). The actionable part was the startup crash on a bad config, which this fixes.

## Testing

- Builds clean (0 warnings; warnings-as-errors).
- Manually verified: corrupted `user.config` with garbage, relaunched → app starts with defaults and no crash; a subsequent settings change writes a fresh valid config.

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)