### PR TITLE
Classic: put the File menu above the toolbar (#56)

### DIFF
--- a/HostsFileEditor.WinForm/MainForm.Designer.cs
+++ b/HostsFileEditor.WinForm/MainForm.Designer.cs
@@ -223,8 +223,10 @@ partial class MainForm
         // 
         // toolStripContainer.TopToolStripPanel
         // 
-        this.toolStripContainer.TopToolStripPanel.Controls.Add(this.menuStrip);
+        // Add the toolbar first, then the menu: in a TopToolStripPanel the last-added strip
+        // stacks on top, so the menu must be added last to sit above the toolbar.
         this.toolStripContainer.TopToolStripPanel.Controls.Add(this.toolStrip);
+        this.toolStripContainer.TopToolStripPanel.Controls.Add(this.menuStrip);
         // 
         // statusStrip
         // 


### PR DESCRIPTION
Fixes #56.

The classic (WinForms) File menu was rendering **below** the toolbar. In a `TopToolStripPanel`, among `Dock=Top` strips the **last-added** one stacks on top; the menu was added before the toolbar, so the toolbar ended up above the menu. Swapped the add order in `MainForm.Designer.cs` so the toolbar is added first and the menu last — menu bar now sits at the top.

Likely regressed during the .NET migration. One-line-order change; verified it compiles (Release build clean). Visual confirmation on run pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)