### PR TITLE
Modern: add row-level keyboard accelerators to match classic (#57)

### DIFF
--- a/HostsFileEditor.WinUI/MainWindow.xaml
+++ b/HostsFileEditor.WinUI/MainWindow.xaml
@@ -16,6 +16,13 @@
             <KeyboardAccelerator Key="Y" Modifiers="Control" Invoked="OnRedoAcceleratorInvoked"/>
             <KeyboardAccelerator Key="S" Modifiers="Control" Invoked="OnSaveAcceleratorInvoked"/>
             <KeyboardAccelerator Key="F5" Invoked="OnRefreshAcceleratorInvoked"/>
+            <!-- Row-level accelerators, matching the classic (WinForms) edition. -->
+            <KeyboardAccelerator Key="Delete" Invoked="OnDeleteAcceleratorInvoked"/>
+            <KeyboardAccelerator Key="D" Modifiers="Control" Invoked="OnDuplicateAcceleratorInvoked"/>
+            <KeyboardAccelerator Key="Up" Modifiers="Menu" Invoked="OnMoveUpAcceleratorInvoked"/>
+            <KeyboardAccelerator Key="Down" Modifiers="Menu" Invoked="OnMoveDownAcceleratorInvoked"/>
+            <KeyboardAccelerator Key="Up" Modifiers="Control,Menu" Invoked="OnInsertAboveAcceleratorInvoked"/>
+            <KeyboardAccelerator Key="Down" Modifiers="Control,Menu" Invoked="OnInsertBelowAcceleratorInvoked"/>
         </Grid.KeyboardAccelerators>
         <Grid x:Name="AppTitleBar" Height="42" Padding="0" VerticalAlignment="Top" Background="Transparent">
             <Grid.ColumnDefinitions>
@@ -260,8 +267,8 @@
                             <MenuFlyoutItem x:Name="CtxCut" Text="Cut" Click="OnCutClick" Icon="Cut" KeyboardAcceleratorTextOverride="Ctrl+X" />
                             <MenuFlyoutItem x:Name="CtxPaste" Text="Paste" Click="OnPasteClick" Icon="Paste" KeyboardAcceleratorTextOverride="Ctrl+V" />
                             <MenuFlyoutSeparator />
-                            <MenuFlyoutItem x:Name="CtxAddAbove" Text="Add Above" Click="OnInsertAboveClick"/>
-                            <MenuFlyoutItem x:Name="CtxAddBelow" Text="Add Below" Click="OnInsertBelowClick"/>
+                            <MenuFlyoutItem x:Name="CtxAddAbove" Text="Add Above" Click="OnInsertAboveClick" KeyboardAcceleratorTextOverride="Ctrl+Alt+Up" />
+                            <MenuFlyoutItem x:Name="CtxAddBelow" Text="Add Below" Click="OnInsertBelowClick" KeyboardAcceleratorTextOverride="Ctrl+Alt+Down" />
                             <MenuFlyoutSeparator />
                             <MenuFlyoutItem x:Name="CtxUndo" Text="Undo" Click="OnUndoClick" Icon="Undo" KeyboardAcceleratorTextOverride="Ctrl+Z" />
                             <MenuFlyoutItem x:Name="CtxRedo" Text="Redo" Click="OnRedoClick" Icon="Redo" KeyboardAcceleratorTextOverride="Ctrl+Y" />

--- a/HostsFileEditor.WinUI/MainWindow.xaml.cs
+++ b/HostsFileEditor.WinUI/MainWindow.xaml.cs
@@ -225,6 +225,26 @@ public sealed partial class MainWindow : Window, INotifyPropertyChanged
     private void OnPasteAcceleratorInvoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
         => TryInvokeUnlessTextBox(() => OnPasteClick(this, new RoutedEventArgs()), args);
 
+    // Row-level accelerators matching the classic edition: Del, Ctrl+D, Alt+Up/Down,
+    // Ctrl+Alt+Up/Down. Guarded so they don't hijack text editing in the filter box / cells.
+    private void OnDeleteAcceleratorInvoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
+        => TryInvokeUnlessTextBox(() => OnDeleteClick(this, new RoutedEventArgs()), args);
+
+    private void OnDuplicateAcceleratorInvoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
+        => TryInvokeUnlessTextBox(() => OnDuplicateClick(this, new RoutedEventArgs()), args);
+
+    private void OnMoveUpAcceleratorInvoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
+        => TryInvokeUnlessTextBox(() => OnMoveUpClick(this, new RoutedEventArgs()), args);
+
+    private void OnMoveDownAcceleratorInvoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
+        => TryInvokeUnlessTextBox(() => OnMoveDownClick(this, new RoutedEventArgs()), args);
+
+    private void OnInsertAboveAcceleratorInvoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
+        => TryInvokeUnlessTextBox(() => OnInsertAboveClick(this, new RoutedEventArgs()), args);
+
+    private void OnInsertBelowAcceleratorInvoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
+        => TryInvokeUnlessTextBox(() => OnInsertBelowClick(this, new RoutedEventArgs()), args);
+
     private async void OnImportClick(object sender, RoutedEventArgs e)
     {
         try


### PR DESCRIPTION
Fixes #57.

The modern (WinUI) edition was missing the row-level keyboard shortcuts the classic edition has — most visibly, **Del did nothing on a selected row**. Added grid-level `KeyboardAccelerator`s (each guarded by the existing `TryInvokeUnlessTextBox` so they don't interfere with text editing in the filter box / cells), matching the classic shortcuts exactly:

| Action | Shortcut |
|---|---|
| Delete rows | Del |
| Duplicate | Ctrl+D |
| Move Up | Alt+Up |
| Move Down | Alt+Down |
| Insert Above | Ctrl+Alt+Up |
| Insert Below | Ctrl+Alt+Down |

They reuse the existing `OnDeleteClick`/`OnDuplicateClick`/`OnMoveUpClick`/`OnMoveDownClick`/`OnInsertAboveClick`/`OnInsertBelowClick` handlers, so behavior matches the toolbar buttons. Also surfaced the Add Above/Below shortcuts in the context menu for parity.

Verified: WinUI builds clean. Functional key-press verification pending on run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)