### PR TITLE
Warn about unsaved changes on exit (both editions) (#58)

### DIFF
--- a/HostsFileEditor.Core/HostsFile.cs
+++ b/HostsFileEditor.Core/HostsFile.cs
@@ -46,6 +46,10 @@ public class HostsFile : INotifyPropertyChanged
     // Save/Refresh keep targeting the current file rather than the path frozen at construction.
     private string _filePath;
 
+    // Undo position captured at the last point the in-memory entries matched the saved file
+    // (load / refresh / save). IsModified compares the current position against it.
+    private object? _cleanStateToken;
+
     private HostsFile(string filePath)
     {
         _filePath = filePath;
@@ -67,7 +71,22 @@ public class HostsFile : INotifyPropertyChanged
         }
 
         Entries.ListChanged += OnHostsEntriesListChanged;
+
+        // Freshly loaded from disk: no unsaved changes.
+        MarkClean();
     }
+
+    // Records the current undo position as the "saved" state. Called when the in-memory entries
+    // match the file on disk (initial load, refresh, save). Import/RestoreDefault deliberately
+    // do NOT call this: they load content that has not yet been written to the hosts file, so
+    // the app should still consider it modified (a save is needed).
+    private void MarkClean() => _cleanStateToken = UndoManager.Instance.CurrentStateToken;
+
+    /// <summary>
+    /// Gets a value indicating whether there are in-memory edits that have not been saved to the
+    /// hosts file, so the UI can warn before discarding them (e.g. on exit).
+    /// </summary>
+    public bool IsModified => !ReferenceEquals(UndoManager.Instance.CurrentStateToken, _cleanStateToken);
 
     public event PropertyChangedEventHandler? PropertyChanged;
 
@@ -147,6 +166,9 @@ public class HostsFile : INotifyPropertyChanged
     {
         SaveAs(_filePath);
         NativeMethods.FlushDns();
+
+        // Entries now match the file on disk.
+        MarkClean();
     }
 
     public void SaveAs(string saveFilePath)
@@ -183,6 +205,9 @@ public class HostsFile : INotifyPropertyChanged
         });
 
         NativeMethods.FlushDns();
+
+        // Entries were just reloaded from the live file, so they match disk.
+        MarkClean();
     }
 
     protected void OnPropertyChanged(string property) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(property));

--- a/HostsFileEditor.Core/Utilities/UndoManager.cs
+++ b/HostsFileEditor.Core/Utilities/UndoManager.cs
@@ -34,6 +34,12 @@ public class UndoManager
     public bool CanUndo => _undoActionsPosition != _undoActions.First;
     public bool CanRedo => _redoActionsPosition != _redoActions.Last;
 
+    // Opaque token identifying the current position in the undo history. It reference-compares
+    // equal only when the history is back at the same position, so callers can detect whether
+    // anything has changed since a captured token (e.g. unsaved edits since the last save). It
+    // changes as actions are added/undone/redone and whenever the history is cleared.
+    public object CurrentStateToken => _undoActionsPosition;
+
     // Event raised when the undo/redo history changes (so UI can update)
     public event EventHandler? HistoryChanged;
 

--- a/HostsFileEditor.WinForm/MainForm.cs
+++ b/HostsFileEditor.WinForm/MainForm.cs
@@ -631,8 +631,56 @@ internal sealed partial class MainForm : Form
     /// </param>
     private void OnExitClick(object sender, EventArgs e)
     {
+        // File > Exit / tray Exit is the true-exit path (closing the window only hides to tray),
+        // so warn about unsaved changes here before actually exiting.
+        if (!ConfirmDiscardUnsavedChanges())
+        {
+            return;
+        }
+
         SaveSettings();
         Application.Exit();
+    }
+
+    /// <summary>
+    /// If there are unsaved hosts-file changes, prompts to save/discard/cancel. Returns true if
+    /// the caller should proceed with exiting (saved or discarded), false to abort the exit.
+    /// </summary>
+    private bool ConfirmDiscardUnsavedChanges()
+    {
+        if (!HostsFile.Instance.IsModified)
+        {
+            return true;
+        }
+
+        var result = MessageBox.Show(
+            this,
+            "You have unsaved changes to the hosts file. Save them before exiting?",
+            "Unsaved Changes",
+            MessageBoxButtons.YesNoCancel,
+            MessageBoxIcon.Warning);
+
+        switch (result)
+        {
+            case DialogResult.Yes:
+                try
+                {
+                    HostsFile.Instance.Save();
+                }
+                catch (Elevation.ElevationCancelledException)
+                {
+                    // Declined the elevation prompt; abort the exit so changes aren't lost.
+                    return false;
+                }
+
+                return true;
+
+            case DialogResult.No:
+                return true;
+
+            default:
+                return false;
+        }
     }
 
     /// <summary>

--- a/HostsFileEditor.WinUI/MainWindow.xaml.cs
+++ b/HostsFileEditor.WinUI/MainWindow.xaml.cs
@@ -162,7 +162,59 @@ public sealed partial class MainWindow : Window, INotifyPropertyChanged
             appWindow.Changed += (_, __) => UpdateTitleBarPadding(appWindow);
             SizeChanged += (_, __) => UpdateTitleBarPadding(appWindow);
             UpdateTitleBarPadding(appWindow);
+
+            // Warn about unsaved changes before the window closes (true exit; WinUI has no tray).
+            appWindow.Closing += OnAppWindowClosing;
         }
+    }
+
+    // Set once the user has chosen to discard/save so the re-close isn't intercepted again.
+    private bool _forceClose;
+
+    private async void OnAppWindowClosing(AppWindow sender, AppWindowClosingEventArgs args)
+    {
+        if (_forceClose || !HostsFile.Instance.IsModified)
+        {
+            return;
+        }
+
+        // Cancel this close; re-close only after the user decides (the dialog is async).
+        args.Cancel = true;
+
+        var choice = await _dialogService.ShowThreeWayAsync(
+            Content.XamlRoot,
+            "Unsaved changes",
+            "You have unsaved changes to the hosts file. Save them before exiting?",
+            primaryText: "Save",
+            secondaryText: "Don't save",
+            closeText: "Cancel");
+
+        if (choice == ContentDialogResult.None)
+        {
+            // Cancel: keep the window open.
+            return;
+        }
+
+        if (choice == ContentDialogResult.Primary)
+        {
+            try
+            {
+                HostsFile.Instance.Save();
+            }
+            catch (Elevation.ElevationCancelledException)
+            {
+                // Declined the elevation prompt; keep the window open so changes aren't lost.
+                return;
+            }
+            catch (Exception ex)
+            {
+                await ShowErrorDialogAsync("Save failed", ex.Message);
+                return;
+            }
+        }
+
+        _forceClose = true;
+        Close();
     }
 
     private void UpdateTitleBarPadding(AppWindow appWindow)

--- a/HostsFileEditor.WinUI/Services/DialogService.cs
+++ b/HostsFileEditor.WinUI/Services/DialogService.cs
@@ -33,6 +33,26 @@ public class DialogService
         return result == ContentDialogResult.Primary;
     }
 
+    // Three-way prompt (e.g. Save / Don't Save / Cancel on exit). Returns:
+    //   Primary   -> primary action (e.g. Save)
+    //   Secondary -> secondary action (e.g. Don't Save)
+    //   None      -> close/cancel
+    public async Task<ContentDialogResult> ShowThreeWayAsync(XamlRoot xamlRoot, string title, string message, string primaryText, string secondaryText, string closeText)
+    {
+        var dlg = new ContentDialog
+        {
+            XamlRoot = xamlRoot,
+            Title = title,
+            Content = message,
+            PrimaryButtonText = primaryText,
+            SecondaryButtonText = secondaryText,
+            CloseButtonText = closeText,
+            DefaultButton = ContentDialogButton.Primary
+        };
+
+        return await dlg.ShowAsync();
+    }
+
     public async Task<string?> ShowInputAsync(XamlRoot xamlRoot, string title, string placeholder, string okText = "OK", string cancelText = "Cancel")
     {
         var input = new TextBox { PlaceholderText = placeholder };


### PR DESCRIPTION
Fixes #58.

Prompts to save before discarding unsaved hosts-file changes when the user fully exits.

## Core — accurate dirty signal
- `UndoManager.CurrentStateToken` — opaque identity of the current undo position.
- `HostsFile.IsModified` — compares the current token to the one captured at the last **load / refresh / save** (`MarkClean`). Notes:
  - Unlike `CanUndo`, it does **not** report modified right after a save (Save doesn't clear history).
  - Undoing back to the saved state clears it (token matches again).
  - **Import** and **Restore Default** intentionally leave it modified — that content hasn't been written to the hosts file yet.

## Classic (WinForms)
`OnExitClick` (File > Exit and tray Exit — the true-exit path; closing the window only hides to tray) prompts **Save / Don't Save / Cancel** when modified. Declining the elevation (UAC) prompt aborts the exit so changes aren't lost.

## Modern (WinUI)
WinUI has no tray, so the window close is the true exit. Intercepts `AppWindow.Closing`, shows a new `DialogService.ShowThreeWayAsync` (Save / Don't Save / Cancel), then re-closes via a guard flag. Save errors / declined elevation keep the window open.

## Verification
- Both editions build clean.
- Core tests: 89/91 pass. The 2 failures are `ProgramSingleInstanceAdditionalTests` (mutex) and are environmental — they fail only because a Hosts File Editor instance was running locally during the test run; unrelated to this change.
- Behavioral verification (the actual prompt on exit) pending on run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)