### PR TITLE
Release 1.3.2

### DIFF
--- a/HostsFileEditor.WinForm/HostsFileEditor.WinForm.csproj
+++ b/HostsFileEditor.WinForm/HostsFileEditor.WinForm.csproj
@@ -22,7 +22,7 @@
     <!-- Single version source for this app: drives AssemblyVersion, FileVersion, the exe's
          ProductVersion resource, and (stamped in Directory.Build.targets) the MSIX manifest
          Identity/@Version. ProductVersion is not an SDK-recognized property and was ignored. -->
-    <Version>1.3.1.0</Version>
+    <Version>1.3.2.0</Version>
     <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
     <!-- Native AOT isn't working yet with WinForms, specifically Binding is explicitly not supported throwing NotSupportedException -->
     <!--<PublishAot>true</PublishAot>-->

--- a/HostsFileEditor.WinUI/HostsFileEditor.WinUI.csproj
+++ b/HostsFileEditor.WinUI/HostsFileEditor.WinUI.csproj
@@ -7,7 +7,7 @@
     <!-- Single version source for this app (the modern UI ships as its own version stream,
          separate from classic). Drives AssemblyVersion/FileVersion/ProductVersion and, stamped
          in Directory.Build.targets, the MSIX manifest Identity/@Version. -->
-    <Version>1.0.1.0</Version>
+    <Version>1.0.2.0</Version>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platform Condition="'$(Platform)' == ''">x64</Platform>
     <Platforms>x64;arm64</Platforms>

--- a/Readme.md
+++ b/Readme.md
@@ -52,14 +52,16 @@ Installs and updates automatically, with no separate download:
  * [Hosts File Editor (modern)](https://apps.microsoft.com/detail/9NBQWCDXGF9R) &mdash; the new WinUI edition
  * [Hosts File Editor (classic)](https://apps.microsoft.com/detail/9NF73PSPK332) &mdash; the classic WinForms edition
 
-### Portable &mdash; v1.3.1
+### Portable &mdash; v1.3.2
 
 The **classic edition** rebuilt on .NET 10: fully self-contained (no runtime to install), runs as a standard user, and elevates on demand (a single UAC prompt) only when you save changes to the hosts file. Binaries are signed. Download directly from [GitHub Releases](https://github.com/scottlerch/HostsFileEditor/releases):
 
- * [Download v1.3.1 portable &mdash; x64](https://github.com/scottlerch/HostsFileEditor/releases/download/v1.3.1/HostsFileEditor-1.3.1-x64.zip)
- * [Download v1.3.1 portable &mdash; ARM64](https://github.com/scottlerch/HostsFileEditor/releases/download/v1.3.1/HostsFileEditor-1.3.1-arm64.zip)
+ * [Download v1.3.2 portable &mdash; x64](https://github.com/scottlerch/HostsFileEditor/releases/download/v1.3.2/HostsFileEditor-1.3.2-x64.zip)
+ * [Download v1.3.2 portable &mdash; ARM64](https://github.com/scottlerch/HostsFileEditor/releases/download/v1.3.2/HostsFileEditor-1.3.2-arm64.zip)
 
-_What's new since v1.2.0:_ a new **modern edition** (WinUI 3) on the Microsoft Store, native **ARM64** builds, a move to **.NET 10** with self-contained deployment, **on-demand elevation** (the app no longer runs entirely as administrator), per-user data under `%LocalAppData%\HostsFileEditor`, Authenticode-signed binaries, and many correctness fixes to undo/redo, move, cut/copy/paste, import/export, and filtering. See the [full release notes](https://github.com/scottlerch/HostsFileEditor/releases/tag/v1.3.1).
+_What's new in v1.3.2:_ high-DPI polish and fixes &mdash; the classic edition is now **PerMonitorV2 DPI-aware** (crisp on 4K / scaled displays) with sharper toolbar icons; the taskbar icon renders **unplated** and the elevation prompt shows the app icon (both editions); the **File menu** sits above the toolbar again (classic); the modern edition gained the missing **row keyboard shortcuts** (Del, Ctrl+D, Alt+Arrow move, Ctrl+Alt+Arrow insert); and both editions now **warn about unsaved changes on exit**. See the [full release notes](https://github.com/scottlerch/HostsFileEditor/releases/tag/v1.3.2).
+
+_What's new since v1.2.0:_ a new **modern edition** (WinUI 3) on the Microsoft Store, native **ARM64** builds, a move to **.NET 10** with self-contained deployment, **on-demand elevation** (the app no longer runs entirely as administrator), per-user data under `%LocalAppData%\HostsFileEditor`, Authenticode-signed binaries, and many correctness fixes to undo/redo, move, cut/copy/paste, import/export, and filtering.
 
 ### Legacy &mdash; v1.2.0
 


### PR DESCRIPTION
Cuts the **1.3.2** polish release. Rebased onto master, so it carries all merged fixes plus:
- version bumps — classic `1.3.2.0`, modern `1.0.2.0`
- `Readme.md` download section updated to v1.3.2

Merge this **last** (after all fix PRs, which are already in). Then build **signed** artifacts, tag `v1.3.2`, and publish.

---

## Hosts File Editor v1.3.2 (release notes)

A polish release focused on high-DPI, icons, and cross-edition consistency.

**High-DPI**
- Classic (WinForms) is now **PerMonitorV2** DPI-aware — crisp on 4K / scaled displays, correct rescaling across mixed-DPI monitors.
- Toolbar/menu icons sharpened for high-DPI (same look).

**Icons & packaging**
- **Taskbar / Alt+Tab icon renders unplated** (no accent-color plate) — both editions.
- **Elevation (UAC) prompt shows the app icon**.
- Sharper tile/logo assets.
- Classic **uninstall entry** now reads "Hosts File Editor (classic)".

**Behavior / parity**
- Classic: **File menu** is above the toolbar again.
- Modern: added missing **row shortcuts** — Delete, Ctrl+D, Alt+↑/↓ (move), Ctrl+Alt+↑/↓ (insert).
- Both: **warn about unsaved changes on exit**.

Included via merged PRs: #54, #55, #59, #60, #61, #63 (issues #24, #56, #57, #58).