### PR TITLE
Fix follow-ups: classic menu order + modern row accelerators

### DIFF
--- a/HostsFileEditor.WinForm/MainForm.cs
+++ b/HostsFileEditor.WinForm/MainForm.cs
@@ -51,6 +51,17 @@ internal sealed partial class MainForm : Form
     {
         InitializeComponent();
 
+        // The ToolStripContainer's top panel doesn't reliably order the two strips from the
+        // designer (Dock=None + Location isn't honored for row order, so the menu ends up below
+        // the toolbar). Pin the rows explicitly: menu on top (row 0), toolbar beneath (row 1).
+        var topPanel = toolStripContainer.TopToolStripPanel;
+        topPanel.SuspendLayout();
+        topPanel.Controls.Remove(menuStrip);
+        topPanel.Controls.Remove(toolStrip);
+        topPanel.Join(menuStrip, 0);
+        topPanel.Join(toolStrip, 1);
+        topPanel.ResumeLayout(true);
+
         // Must be a directory: setting InitialDirectory to the hosts *file* path made Windows
         // ignore it, so Save As opened in the default location instead of the etc directory.
         saveFileDialog.InitialDirectory = HostsFile.DefaultHostFileDirectory;

--- a/HostsFileEditor.WinUI/MainWindow.xaml
+++ b/HostsFileEditor.WinUI/MainWindow.xaml
@@ -16,13 +16,14 @@
             <KeyboardAccelerator Key="Y" Modifiers="Control" Invoked="OnRedoAcceleratorInvoked"/>
             <KeyboardAccelerator Key="S" Modifiers="Control" Invoked="OnSaveAcceleratorInvoked"/>
             <KeyboardAccelerator Key="F5" Invoked="OnRefreshAcceleratorInvoked"/>
-            <!-- Row-level accelerators, matching the classic (WinForms) edition. -->
+            <!-- Row-level accelerators, matching the classic (WinForms) edition. Delete and Ctrl+D
+                 are not arrow keys, so they don't collide with ListView navigation and work as
+                 accelerators. The Alt+Arrow (move) and Ctrl+Alt+Arrow (insert) combos DO collide —
+                 the ListView consumes the arrow key for navigation before the accelerator can fire
+                 (except at the first/last row, where it can't navigate) — so those are handled in
+                 EntriesList's tunneling PreviewKeyDown instead. -->
             <KeyboardAccelerator Key="Delete" Invoked="OnDeleteAcceleratorInvoked"/>
             <KeyboardAccelerator Key="D" Modifiers="Control" Invoked="OnDuplicateAcceleratorInvoked"/>
-            <KeyboardAccelerator Key="Up" Modifiers="Menu" Invoked="OnMoveUpAcceleratorInvoked"/>
-            <KeyboardAccelerator Key="Down" Modifiers="Menu" Invoked="OnMoveDownAcceleratorInvoked"/>
-            <KeyboardAccelerator Key="Up" Modifiers="Control,Menu" Invoked="OnInsertAboveAcceleratorInvoked"/>
-            <KeyboardAccelerator Key="Down" Modifiers="Control,Menu" Invoked="OnInsertBelowAcceleratorInvoked"/>
         </Grid.KeyboardAccelerators>
         <Grid x:Name="AppTitleBar" Height="42" Padding="0" VerticalAlignment="Top" Background="Transparent">
             <Grid.ColumnDefinitions>
@@ -249,6 +250,7 @@
                 <ListView x:Name="EntriesList"
                           Grid.Row="1"
                           Margin="0,8,0,0"
+                          PreviewKeyDown="OnEntriesPreviewKeyDown"
                           SelectionMode="Extended"
                           HorizontalContentAlignment="Stretch"
                           ScrollViewer.HorizontalScrollBarVisibility="Disabled"

--- a/HostsFileEditor.WinUI/MainWindow.xaml.cs
+++ b/HostsFileEditor.WinUI/MainWindow.xaml.cs
@@ -1,6 +1,7 @@
 using HostsFileEditor.Services;
 using HostsFileEditor.Win32;
 using Microsoft.UI;
+using Microsoft.UI.Input;
 using Microsoft.UI.Composition;
 using Microsoft.UI.Composition.SystemBackdrops;
 using Microsoft.UI.Windowing;
@@ -10,6 +11,7 @@ using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using Windows.System;
 using WinRT;
 using WinRT.Interop;
 
@@ -285,17 +287,39 @@ public sealed partial class MainWindow : Window, INotifyPropertyChanged
     private void OnDuplicateAcceleratorInvoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
         => TryInvokeUnlessTextBox(() => OnDuplicateClick(this, new RoutedEventArgs()), args);
 
-    private void OnMoveUpAcceleratorInvoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
-        => TryInvokeUnlessTextBox(() => OnMoveUpClick(this, new RoutedEventArgs()), args);
+    // Alt+Up/Down (move) and Ctrl+Alt+Up/Down (insert) can't be plain KeyboardAccelerators: the
+    // ListView consumes the arrow key for navigation before the accelerator fires (so move never
+    // worked, and insert only worked at the first/last row — the one spot the ListView can't
+    // navigate). Handle them in the tunneling PreviewKeyDown, which runs before the ListView's own
+    // key handling, and mark them handled so the selection doesn't also move.
+    private void OnEntriesPreviewKeyDown(object sender, KeyRoutedEventArgs e)
+    {
+        if (e.Key is not (VirtualKey.Up or VirtualKey.Down) || IsTextBoxFocused())
+        {
+            return;
+        }
 
-    private void OnMoveDownAcceleratorInvoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
-        => TryInvokeUnlessTextBox(() => OnMoveDownClick(this, new RoutedEventArgs()), args);
+        var alt = IsKeyDown(VirtualKey.Menu);
+        if (!alt)
+        {
+            return;
+        }
 
-    private void OnInsertAboveAcceleratorInvoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
-        => TryInvokeUnlessTextBox(() => OnInsertAboveClick(this, new RoutedEventArgs()), args);
+        var ctrl = IsKeyDown(VirtualKey.Control);
+        if (e.Key == VirtualKey.Up)
+        {
+            if (ctrl) { OnInsertAboveClick(this, new RoutedEventArgs()); } else { OnMoveUpClick(this, new RoutedEventArgs()); }
+        }
+        else
+        {
+            if (ctrl) { OnInsertBelowClick(this, new RoutedEventArgs()); } else { OnMoveDownClick(this, new RoutedEventArgs()); }
+        }
 
-    private void OnInsertBelowAcceleratorInvoked(KeyboardAccelerator sender, KeyboardAcceleratorInvokedEventArgs args)
-        => TryInvokeUnlessTextBox(() => OnInsertBelowClick(this, new RoutedEventArgs()), args);
+        e.Handled = true;
+    }
+
+    private static bool IsKeyDown(VirtualKey key) =>
+        InputKeyboardSource.GetKeyStateForCurrentThread(key).HasFlag(Windows.UI.Core.CoreVirtualKeyStates.Down);
 
     private async void OnImportClick(object sender, RoutedEventArgs e)
     {


### PR DESCRIPTION
Two follow-up fixes found during testing of the merged 1.3.2 polish work.

## Classic: File menu still below the toolbar (follow-up to #56)
The add-order swap in #56 didn't actually reorder the strips. In the `ToolStripContainer`'s top panel both strips are `Dock=None` and the designer's `Location` values aren't honored for row order, so the menu kept rendering below the toolbar. Now pinned explicitly at construction via `ToolStripPanel.Join(menuStrip, 0)` / `Join(toolStrip, 1)`.

## Modern: Alt+Arrow move / Ctrl+Alt+Arrow insert didn't work (follow-up to #57)
Root cause: the `ListView` consumes arrow keys for navigation **before** a `KeyboardAccelerator` can fire. So:
- **Alt+↑/↓ (move)** never fired.
- **Ctrl+Alt+↑/↓ (insert)** fired **only at the first/last row** — the one place the ListView can't navigate, so the key bubbled to the accelerator.

Fix: handle these four combos in `EntriesList`'s tunneling `PreviewKeyDown` (runs before the ListView's own key handling) and mark them handled so selection doesn't also move. `Delete` and `Ctrl+D` stay as accelerators — they aren't arrow keys, so they don't collide.

## Verification
Both editions build clean. Behavioral verification on run (fresh test artifacts provided).