### PR TITLE
Parse host entries with trailing-dot (FQDN) hostnames

### DIFF
--- a/HostsFileEditor.Core.Tests/HostsEntryTests.cs
+++ b/HostsFileEditor.Core.Tests/HostsEntryTests.cs
@@ -142,6 +142,22 @@ public class HostsEntryTests
     }
 
     [TestMethod]
+    [DataRow("# TailscaleHostsSectionStart")]
+    [DataRow("# This section contains MagicDNS entries for Tailscale.")]
+    [DataRow("# Do not edit this section manually.")]
+    public void Parse_ProseComment_EndingInDot_StaysComment(string raw)
+    {
+        // Prose comment lines that happen to end in '.' must not be captured as (invalid)
+        // disabled entries now that hostnames accept a trailing dot. The leading '#' with a
+        // non-IP first token must keep them comment-only and round-trip verbatim.
+        var entry = new HostsEntry(raw);
+        entry.HasCommentOnly.ShouldBeTrue();
+        entry.Valid.ShouldBeFalse();
+        entry.Enabled.ShouldBeFalse();
+        entry.UnparsedText.ShouldBe(raw);
+    }
+
+    [TestMethod]
     public void Parse_IPv6()
     {
         var entry = new HostsEntry("::1 localhost");

--- a/HostsFileEditor.Core.Tests/HostsEntryTests.cs
+++ b/HostsFileEditor.Core.Tests/HostsEntryTests.cs
@@ -109,6 +109,19 @@ public class HostsEntryTests
     }
 
     [TestMethod]
+    public void Parse_FqdnTrailingDot_IsValid()
+    {
+        // Tailscale MagicDNS writes every entry as a fully-qualified name ending in a root dot.
+        // The trailing dot must not demote the line to a comment, and it must round-trip.
+        const string raw = "100.64.0.1 host.tailnet.ts.net. host";
+        var entry = new HostsEntry(raw);
+        entry.Valid.ShouldBeTrue();
+        entry.IpAddress.ShouldBe("100.64.0.1");
+        entry.HostNames.ShouldBe("host.tailnet.ts.net. host");
+        entry.UnparsedText.ShouldBe(raw);
+    }
+
+    [TestMethod]
     public void Parse_IPv6()
     {
         var entry = new HostsEntry("::1 localhost");

--- a/HostsFileEditor.Core.Tests/HostsEntryTests.cs
+++ b/HostsFileEditor.Core.Tests/HostsEntryTests.cs
@@ -122,6 +122,26 @@ public class HostsEntryTests
     }
 
     [TestMethod]
+    public void Parse_FqdnTrailingDot_WithAfterComment()
+    {
+        var entry = new HostsEntry("100.64.0.1 host.tailnet.ts.net. host # note");
+        entry.Valid.ShouldBeTrue();
+        entry.IpAddress.ShouldBe("100.64.0.1");
+        entry.HostNames.ShouldBe("host.tailnet.ts.net. host");
+        entry.Comment.ShouldBe("note");
+    }
+
+    [TestMethod]
+    public void Parse_FqdnTrailingDot_IPv6()
+    {
+        // Tailscale MagicDNS also writes AAAA entries in the fd7a:115c::/48 range.
+        var entry = new HostsEntry("fd7a:115c:a1e0::1 host.tailnet.ts.net. host");
+        entry.Valid.ShouldBeTrue();
+        entry.IpAddress.ShouldBe("fd7a:115c:a1e0::1");
+        entry.HostNames.ShouldBe("host.tailnet.ts.net. host");
+    }
+
+    [TestMethod]
     public void Parse_IPv6()
     {
         var entry = new HostsEntry("::1 localhost");

--- a/HostsFileEditor.Core/HostsEntry.cs
+++ b/HostsFileEditor.Core/HostsEntry.cs
@@ -387,7 +387,7 @@ public partial class HostsEntry : INotifyPropertyChanged, IDataErrorInfo
     [GeneratedRegex(@"[ ]{2,}")]
     private static partial Regex TwoSpaceMatchRegex();
 
-    [GeneratedRegex(@"^([\w-]+\.)*([\w-]+)((\s)+([\w-]+\.)*([\w-]+))*$")]
+    [GeneratedRegex(@"^([\w-]+\.)*([\w-]+)\.?((\s)+([\w-]+\.)*([\w-]+)\.?)*$")]
     private static partial Regex HostNameRegex();
 
     // Each alternative is anchored with ^...$ so a line must match a pattern in full. Without
@@ -400,6 +400,10 @@ public partial class HostsEntry : INotifyPropertyChanged, IDataErrorInfo
     // optional '#' still parses as an entry (issue #22). Without it, \s* consumed the leading
     // space and '#' was captured as the ipaddress, demoting a valid disabled entry (e.g.
     // " # 1.2.3.4 host") to a plain comment.
-    [GeneratedRegex(@"^(\s*(?<disabled>#+)?\s*(?<ipaddress>[^\s]+)\s+(?<hostname>([\w-]+\.)*([\w-]+)((\s)+([\w-]+\.)*([\w-]+))*)\s*(#+(?<aftercomment>.*))?)$|^(\s*#+\s?(?<comment>.*))$|^(?<blank>\s*)$", RegexOptions.Compiled)]
+    //
+    // Each hostname token allows one optional trailing '.' so fully-qualified names (e.g. the
+    // Tailscale MagicDNS "host.tailnet.ts.net.") parse as entries rather than falling through
+    // to the comment alternative.
+    [GeneratedRegex(@"^(\s*(?<disabled>#+)?\s*(?<ipaddress>[^\s]+)\s+(?<hostname>([\w-]+\.)*([\w-]+)\.?((\s)+([\w-]+\.)*([\w-]+)\.?)*)\s*(#+(?<aftercomment>.*))?)$|^(\s*#+\s?(?<comment>.*))$|^(?<blank>\s*)$", RegexOptions.Compiled)]
     private static partial Regex ValidHostsRegex();
 }


### PR DESCRIPTION
Fixes #65.

Tailscale MagicDNS writes every entry as a fully-qualified name ending in a root dot (e.g. `host.tailnet.ts.net.`). The hostname sub-pattern `([\w-]+\.)*([\w-]+)` in `ValidHostsRegex()` and `HostNameRegex()` rejected that trailing dot, so the lines matched none of the `^...$` alternatives and were surfaced as comments (`Host Entries: 0`).

### Change

- Allow one optional trailing dot per hostname token (`...([\w-]+)\.?...`) in both regexes.
- Add `Parse_FqdnTrailingDot_IsValid` covering the FQDN case and round-trip.

### Verification

`dotnet test HostsFileEditor.Core.Tests` → **92 passed, 0 failed**. The change is purely permissive (one optional trailing dot per label); plain entries, multi-hostname, IPv6, tab/leading-whitespace, disabled entries, and invalid inputs (`bad@host`, `localhost:8080`) all parse exactly as before.
