### PR TITLE
Patch 1.4.1 / 1.1.1: Move→Insert anchor fix + 400K double-filter perf

### DIFF
--- a/HostsFileEditor.WinForm/Controls/HostsEntryDataGridView.cs
+++ b/HostsFileEditor.WinForm/Controls/HostsEntryDataGridView.cs
@@ -409,14 +409,16 @@ internal sealed class HostsEntryDataGridView : DataGridView
 
     /// <summary>
     /// Re-establishes the current-cell anchor on the row now holding <paramref name="anchorEntry"/>
-    /// after a sort's Reset (<see cref="FinalizePendingNewRow"/> nulled <see cref="DataGridView.CurrentCell"/>
-    /// to fire the new-row commit). Without this the Insert Above/Below and Move Up/Down fallbacks that
-    /// key off <see cref="CurrentHostEntry"/> silently no-op until the user re-clicks a row. Called
-    /// BEFORE the selection is restored (so setting the anchor can't collapse a multi-row selection) and
-    /// only for selections within the restore cap — a huge selection drops both the selection and the
-    /// anchor by design, so the caller skips this scan there.
+    /// after a Reset reordered the view. The framework keeps <see cref="DataGridView.CurrentCell"/> at
+    /// a fixed row INDEX across a Reset, so after a sort or a Move that index holds a different entry and
+    /// <see cref="CurrentHostEntry"/> drifts — the Insert Above/Below and Move Up/Down handlers that key
+    /// off it would then act on (or no-op against) the wrong entry. Used by the sort (which also nulls
+    /// CurrentCell via <see cref="FinalizePendingNewRow"/> to fire the new-row commit) and by Move.
+    /// Called BEFORE the selection is restored, so setting the anchor can't collapse a multi-row
+    /// selection, and only for selections within the restore cap — a huge selection drops both the
+    /// selection and the anchor by design, so the caller skips this scan there.
     /// </summary>
-    private void RestoreCurrentCell(HostsEntry? anchorEntry, int anchorColumnIndex)
+    internal void RestoreCurrentCell(HostsEntry? anchorEntry, int anchorColumnIndex)
     {
         if (anchorEntry is null || anchorColumnIndex < 0 || BoundView() is not { } view)
         {

--- a/HostsFileEditor.WinForm/HostsFileEditor.WinForm.csproj
+++ b/HostsFileEditor.WinForm/HostsFileEditor.WinForm.csproj
@@ -22,7 +22,7 @@
     <!-- Single version source for this app: drives AssemblyVersion, FileVersion, the exe's
          ProductVersion resource, and (stamped in Directory.Build.targets) the MSIX manifest
          Identity/@Version. ProductVersion is not an SDK-recognized property and was ignored. -->
-    <Version>1.4.0.0</Version>
+    <Version>1.4.1.0</Version>
     <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
     <!-- Native AOT isn't working yet with WinForms, specifically Binding is explicitly not supported throwing NotSupportedException -->
     <!--<PublishAot>true</PublishAot>-->

--- a/HostsFileEditor.WinForm/MainForm.cs
+++ b/HostsFileEditor.WinForm/MainForm.cs
@@ -903,6 +903,14 @@ internal sealed partial class MainForm : Form
     /// </param>
     private void OnMoveDownClick(object sender, EventArgs e)
     {
+        // Capture the current-cell anchor before the move: the move's Reset keeps CurrentCell at the
+        // same row INDEX, which then holds a DIFFERENT entry, so CurrentRow/CurrentHostEntry silently
+        // drift — a following Insert Above/Below (which reads only CurrentRow) would act on the wrong
+        // entry (#78). Re-anchor by identity after the move, BEFORE the selection restore so setting
+        // CurrentCell can't collapse the restored multi-row selection (same ordering as the sort path).
+        var anchorEntry = dataGridViewHostsEntries.CurrentHostEntry;
+        var anchorColumn = dataGridViewHostsEntries.CurrentCell?.ColumnIndex ?? -1;
+
         if (dataGridViewHostsEntries.SelectedRowCount > 0)
         {
             var selectedEntries = dataGridViewHostsEntries.SelectedHostEntries.ToList();
@@ -919,6 +927,7 @@ internal sealed partial class MainForm : Form
                 dataGridViewHostsEntries.ClearSelection();
                 HostsFile.Instance.Entries.MoveAfter(selectedEntries, belowEntry);
 
+                dataGridViewHostsEntries.RestoreCurrentCell(anchorEntry, anchorColumn);
                 dataGridViewHostsEntries.SelectedHostEntries = selectedEntries;
             }
         }
@@ -933,6 +942,7 @@ internal sealed partial class MainForm : Form
 
                 HostsFile.Instance.Entries.MoveAfter([currentEntry], belowEntry);
 
+                dataGridViewHostsEntries.RestoreCurrentCell(anchorEntry, anchorColumn);
                 dataGridViewHostsEntries.SelectedHostEntries = selectedEntries;
             }
         }
@@ -949,6 +959,12 @@ internal sealed partial class MainForm : Form
     /// </param>
     private void OnMoveUpClick(object sender, EventArgs e)
     {
+        // See OnMoveDownClick: capture the current-cell anchor before the move and re-anchor by
+        // identity afterwards (before the selection restore) so a following Insert/Move doesn't act on
+        // the drifted CurrentRow (#78).
+        var anchorEntry = dataGridViewHostsEntries.CurrentHostEntry;
+        var anchorColumn = dataGridViewHostsEntries.CurrentCell?.ColumnIndex ?? -1;
+
         if (dataGridViewHostsEntries.SelectedRowCount > 0)
         {
             var selectedEntries = dataGridViewHostsEntries.SelectedHostEntries.ToList();
@@ -963,6 +979,7 @@ internal sealed partial class MainForm : Form
                 dataGridViewHostsEntries.ClearSelection();
                 HostsFile.Instance.Entries.MoveBefore(selectedEntries, aboveEntry);
 
+                dataGridViewHostsEntries.RestoreCurrentCell(anchorEntry, anchorColumn);
                 dataGridViewHostsEntries.SelectedHostEntries = selectedEntries;
             }
         }
@@ -977,6 +994,7 @@ internal sealed partial class MainForm : Form
 
                 HostsFile.Instance.Entries.MoveBefore([currentEntry], aboveEntry);
 
+                dataGridViewHostsEntries.RestoreCurrentCell(anchorEntry, anchorColumn);
                 dataGridViewHostsEntries.SelectedHostEntries = selectedEntries;
             }
         }

--- a/HostsFileEditor.WinForm/MainForm.cs
+++ b/HostsFileEditor.WinForm/MainForm.cs
@@ -927,7 +927,14 @@ internal sealed partial class MainForm : Form
                 dataGridViewHostsEntries.ClearSelection();
                 HostsFile.Instance.Entries.MoveAfter(selectedEntries, belowEntry);
 
-                dataGridViewHostsEntries.RestoreCurrentCell(anchorEntry, anchorColumn);
+                // Skip the anchor re-find for a huge selection: the restore below drops it and nulls
+                // CurrentCell anyway (its >MaxSelectionRestoreCount branch), so the O(n) scan + scroll
+                // would be wasted — same gate the sort path uses.
+                if (selectedEntries.Count <= HostsEntryList.HugeSelectionThreshold)
+                {
+                    dataGridViewHostsEntries.RestoreCurrentCell(anchorEntry, anchorColumn);
+                }
+
                 dataGridViewHostsEntries.SelectedHostEntries = selectedEntries;
             }
         }
@@ -979,7 +986,12 @@ internal sealed partial class MainForm : Form
                 dataGridViewHostsEntries.ClearSelection();
                 HostsFile.Instance.Entries.MoveBefore(selectedEntries, aboveEntry);
 
-                dataGridViewHostsEntries.RestoreCurrentCell(anchorEntry, anchorColumn);
+                // See OnMoveDownClick: skip the wasted anchor re-find for a huge (dropped) selection.
+                if (selectedEntries.Count <= HostsEntryList.HugeSelectionThreshold)
+                {
+                    dataGridViewHostsEntries.RestoreCurrentCell(anchorEntry, anchorColumn);
+                }
+
                 dataGridViewHostsEntries.SelectedHostEntries = selectedEntries;
             }
         }

--- a/HostsFileEditor.WinUI/HostsFileEditor.WinUI.csproj
+++ b/HostsFileEditor.WinUI/HostsFileEditor.WinUI.csproj
@@ -7,7 +7,7 @@
     <!-- Single version source for this app (the modern UI ships as its own version stream,
          separate from classic). Drives AssemblyVersion/FileVersion/ProductVersion and, stamped
          in Directory.Build.targets, the MSIX manifest Identity/@Version. -->
-    <Version>1.1.0.0</Version>
+    <Version>1.1.1.0</Version>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platform Condition="'$(Platform)' == ''">x64</Platform>
     <Platforms>x64;arm64</Platforms>

--- a/HostsFileEditor.WinUI/MainWindow.xaml.cs
+++ b/HostsFileEditor.WinUI/MainWindow.xaml.cs
@@ -312,10 +312,21 @@ public sealed partial class MainWindow : Window, INotifyPropertyChanged
     // and rebind in a single operation, instead of hundreds of thousands of incremental adds.
     private void BulkPopulateEntries(List<HostsEntry>? prefiltered = null)
     {
-        // Filter-change callers pass null and we compute the filtered set here; the RefreshEntries
-        // huge-selection reroute already built the identical set (same EntryPassesFilter predicate),
-        // so it passes it in to avoid filtering the whole (up to ~400K) list a second time (#74).
-        var filtered = prefiltered ?? [.. HostsFile.Instance.Entries.Where(e => EntryPassesFilter(e, CurrentFilterText()))];
+        // Filter-change callers pass null and we compute the filtered set here (hoisting the filter
+        // text to one lookup — NOT per entry); the RefreshEntries huge-selection reroute already built
+        // the identical set (same EntryPassesFilter predicate), so it passes it in to avoid filtering
+        // the whole (up to ~400K) list a second time (#74).
+        List<HostsEntry> filtered;
+        if (prefiltered is not null)
+        {
+            filtered = prefiltered;
+        }
+        else
+        {
+            var filterText = CurrentFilterText();
+            filtered = [.. HostsFile.Instance.Entries.Where(e => EntryPassesFilter(e, filterText))];
+        }
+
         Entries = new ObservableCollection<HostsEntry>(filtered);
         OnPropertyChanged(nameof(Entries));
 

--- a/HostsFileEditor.WinUI/MainWindow.xaml.cs
+++ b/HostsFileEditor.WinUI/MainWindow.xaml.cs
@@ -310,10 +310,12 @@ public sealed partial class MainWindow : Window, INotifyPropertyChanged
 
     // One-shot bulk load of the (filtered) entries: build the list off the persistent collection
     // and rebind in a single operation, instead of hundreds of thousands of incremental adds.
-    private void BulkPopulateEntries()
+    private void BulkPopulateEntries(List<HostsEntry>? prefiltered = null)
     {
-        var filterText = CurrentFilterText();
-        var filtered = HostsFile.Instance.Entries.Where(e => EntryPassesFilter(e, filterText)).ToList();
+        // Filter-change callers pass null and we compute the filtered set here; the RefreshEntries
+        // huge-selection reroute already built the identical set (same EntryPassesFilter predicate),
+        // so it passes it in to avoid filtering the whole (up to ~400K) list a second time (#74).
+        var filtered = prefiltered ?? [.. HostsFile.Instance.Entries.Where(e => EntryPassesFilter(e, CurrentFilterText()))];
         Entries = new ObservableCollection<HostsEntry>(filtered);
         OnPropertyChanged(nameof(Entries));
 
@@ -359,7 +361,7 @@ public sealed partial class MainWindow : Window, INotifyPropertyChanged
     // rather than the per-item minimal diff in RefreshEntries — that diff is O(n^2) with hundreds
     // of thousands of ObservableCollection mutations for a large hosts file, which locks up the UI.
     // Selection is reset, which is the expected behavior when the filter changes.
-    private void RefreshEntriesFiltered()
+    private void RefreshEntriesFiltered(List<HostsEntry>? prefiltered = null)
     {
         // Inert until the initial load completes (and forever if it failed, or while an async
         // reload is rebuilding the Core list on a background thread) — BulkPopulateEntries
@@ -369,7 +371,7 @@ public sealed partial class MainWindow : Window, INotifyPropertyChanged
             return;
         }
 
-        BulkPopulateEntries();
+        BulkPopulateEntries(prefiltered);
         OnPropertyChanged(nameof(EntriesEmptyVisibility));
         OnPropertyChanged(nameof(EntriesFilteredVisibility));
         _selectionService.UpdateSelectionDependentButtons();
@@ -1676,7 +1678,9 @@ public sealed partial class MainWindow : Window, INotifyPropertyChanged
             _suspendSelectionTracking = true;
             try
             {
-                RefreshEntriesFiltered();
+                // Reuse the list we just filtered instead of letting BulkPopulateEntries filter the
+                // whole ~400K list a second time (#74).
+                RefreshEntriesFiltered(newList);
             }
             finally
             {


### PR DESCRIPTION
Low-risk patch — two verified fixes from the 1.4.0/1.1.0 review follow-ups. Bumps classic `1.4.0 → 1.4.1`, modern `1.1.0 → 1.1.1`.

## Fixes
- **#78 (classic bug):** After a Move reorders the list, `DataGridView.CurrentCell` stays at the same row *index* — which now holds a different entry — so a following Insert Above/Below acted on the wrong entry. The Move handlers now re-anchor the current cell by identity (as the sort path already did), gated on the huge-selection cap.
- **#74 (modern perf):** The huge-selection reroute in `RefreshEntries` now reuses the already-filtered list instead of filtering the ~400K entries a second time in `BulkPopulateEntries`.

## Review
Reviewed on the branch before opening (3 focused reviewers). The review caught a **perf regression in the first cut of #74** — a `CurrentFilterText()` call that had moved *inside* the `Where` predicate, running a `FindName` + `Trim` once per entry — and a **missing huge-selection gate** on #78's Move re-anchor. Both fixed in `44e9d85`.

## Verification
Both editions build 0 warnings / 0 errors; the classic sort harness (real grid + Equin, now with a drift→re-anchor check) is **ALL PASS**; **128 Core tests** pass.

## Deferred (not in this patch)
Moved to the [v1.5.0 / v1.2.0 minor milestone](https://github.com/scottlerch/HostsFileEditor/milestone/2) — they touch the parser / classic Equin filter and want a full review cycle: **#75** (filter → Core), **#80** (strict IP validation). **#73** (Equin sort reflection → source-index comparer) was **closed as wontfix** after investigation showed the proposed approach isn't viable (a static index comparer crashes on the next edit) and the current reflection's only failure mode is a cosmetic wrong-order display, not corruption.

Fixes #78
Fixes #74
