### PR TITLE
Add publish-store.ps1: automate Store submissions (msstore CLI) + docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,30 +153,35 @@ local/dev only.
 
 Both editions ship to the Microsoft Store as separate apps — **classic `9NF73PSPK332`**, **modern
 `9NBQWCDXGF9R`**. Instead of the Partner Center portal UI, `publish-store.ps1` scripts the
-submissions with the **Microsoft Store Developer CLI (`msstore`)** — the official CLI over the
-Partner Center APIs (preview; free products only, which both editions are).
+submissions with **StoreBroker** — Microsoft's PowerShell module over the Store submission REST API.
+(The `msstore` CLI was tried first and abandoned: its `publish` builds a project of a recognized
+type and can't push our pre-built, externally-signed MSIX to an existing app by product id.)
 
-- **Install tooling (one-time):** `.\publish-store.ps1 -InstallTooling` — winget-installs the .NET 9
-  Desktop Runtime and the `msstore` CLI. (`msstore` is a separate install; it does not ship with
-  Windows or VS.)
-- **Authenticate (one-time):** create an Azure AD app in Partner Center (Account settings → User
-  management → *Azure AD applications*, **Manager** role) to get the **TenantId / ClientId /
-  ClientSecret**; the numeric **SellerId** is in Account settings. Then
-  `msstore reconfigure --tenantId <T> --sellerId <S> --clientId <C> --clientSecret <SECRET>`. Never
-  commit these — use secrets.
+- **Install tooling (one-time):** `.\publish-store.ps1 -InstallTooling` — `Install-Module StoreBroker
+  -Scope CurrentUser`. Pure PowerShell; no winget/runtime prerequisites.
+- **Authenticate:** create an Azure AD app in Partner Center (Account settings → User management →
+  *Azure AD applications*, **Manager** role) to get the **TenantId / ClientId** and a **client secret**
+  (a "Key"). The script calls `Set-StoreBrokerAuthentication` for you from those three values, resolved
+  in order: `-TenantId`/`-ClientId`/`-ClientSecret` params → `STOREBROKER_TENANTID`/`STOREBROKER_CLIENTID`/
+  `STOREBROKER_CLIENTSECRET` env vars → interactive prompt. The secret stays a `SecureString` and is
+  never written to disk by the script. No SellerId is needed (that was a `msstore`-ism). Never commit
+  the secret — env var or prompt only.
 - **Each release:** `.\build-all.ps1 -Sign` (produces `artifacts\store\HostsFileEditor-<flavor>-<arch>.msix`)
-  then `.\publish-store.ps1` — for each edition it stages that edition's x64+arm64 packages, uploads
-  them into a draft (`msstore publish -i <dir> --noCommit`), patches the "What's new" notes on every
-  listing locale (`Listings.<locale>.BaseListing.ReleaseNotes`), then `submission publish` → `poll`.
-  `-NoCommit` leaves a Draft for a final portal check; `-Edition classic|modern` limits scope;
-  `-Inspect` dumps the current submission JSON.
+  then `.\publish-store.ps1` — for each edition it **clones the current published submission**
+  (`New-ApplicationSubmission -Force`), marks the existing packages `PendingDelete` and adds the new
+  x64+arm64 msix as `PendingUpload`, sets the "What's new" on every listing locale
+  (`listings.<locale>.baseListing.releaseNotes` — note StoreBroker uses the **raw API camelCase**, not
+  msstore's PascalCase), pushes it (`Set-ApplicationSubmission`), uploads the packages as one zip
+  (`Set-SubmissionPackage`), then commits (`Complete-ApplicationSubmission`). Cloning preserves the
+  rich listing (description/screenshots); only packages + notes change. `-NoCommit` leaves a Draft for
+  a final portal check; `-Edition classic|modern` limits scope; `-Inspect` dumps the current submission.
 - **Verify on the first run:** use `-NoCommit` and confirm in Partner Center that **both** architectures
-  uploaded at the new version — `msstore publish -i` takes a directory and the docs describe it as
-  finding "the" package, so if only one arch lands, switch to a single `.msixbundle` (`makeappx bundle`).
+  uploaded at the new version before committing there. The per-package summary line prints each msix's
+  manifest version so a forgotten version bump is caught before upload.
 - **Reruns / partial failure:** each edition publishes independently — if one fails, the other still
-  completes, a per-edition summary prints, and the script exits non-zero. The Store keeps one pending
-  submission per app, so a rerun **resumes** that app's existing draft; `-Edition <name>` retries just
-  one, `msstore submission delete <productId>` discards a draft.
+  completes, a per-edition summary prints, and the script exits non-zero. `New-ApplicationSubmission
+  -Force` discards any half-built pending submission and re-clones from what's published, so a rerun is
+  clean; `-Edition <name>` retries just one.
 
 ## Gotchas
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,12 +165,14 @@ Partner Center APIs (preview; free products only, which both editions are).
   `msstore reconfigure --tenantId <T> --sellerId <S> --clientId <C> --clientSecret <SECRET>`. Never
   commit these — use secrets.
 - **Each release:** `.\build-all.ps1 -Sign` (produces `artifacts\store\HostsFileEditor-<flavor>-<arch>.msix`)
-  then `.\publish-store.ps1` — for each edition it does `msstore submission get` → patch packages +
-  the per-edition "What's new" notes → `submission update` → `publish` → `poll`. `-NoCommit` leaves a
-  Draft for a final portal check; `-Edition classic|modern` limits scope.
-- **Open item:** the exact submission-JSON field paths (`applicationPackages` shape / `releaseNotes`
-  location) vary per account. Run `.\publish-store.ps1 -Inspect` once to dump the JSON and fill in the
-  two marked lines in the script before the first real run.
+  then `.\publish-store.ps1` — for each edition it stages that edition's x64+arm64 packages, uploads
+  them into a draft (`msstore publish -i <dir> --noCommit`), patches the "What's new" notes on every
+  listing locale (`Listings.<locale>.BaseListing.ReleaseNotes`), then `submission publish` → `poll`.
+  `-NoCommit` leaves a Draft for a final portal check; `-Edition classic|modern` limits scope;
+  `-Inspect` dumps the current submission JSON.
+- **Verify on the first run:** use `-NoCommit` and confirm in Partner Center that **both** architectures
+  uploaded at the new version — `msstore publish -i` takes a directory and the docs describe it as
+  finding "the" package, so if only one arch lands, switch to a single `.msixbundle` (`makeappx bundle`).
 
 ## Gotchas
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,29 @@ Tests are MSTest classes (`[TestClass]`/`[TestMethod]`) using **Shouldly** asser
 registry `KitsRoot10`). Test signing cert is `HostsFileEditorTestCert.pfx` (password `test`) — for
 local/dev only.
 
+## Store release automation (`publish-store.ps1`)
+
+Both editions ship to the Microsoft Store as separate apps — **classic `9NF73PSPK332`**, **modern
+`9NBQWCDXGF9R`**. Instead of the Partner Center portal UI, `publish-store.ps1` scripts the
+submissions with the **Microsoft Store Developer CLI (`msstore`)** — the official CLI over the
+Partner Center APIs (preview; free products only, which both editions are).
+
+- **Install tooling (one-time):** `.\publish-store.ps1 -InstallTooling` — winget-installs the .NET 9
+  Desktop Runtime and the `msstore` CLI. (`msstore` is a separate install; it does not ship with
+  Windows or VS.)
+- **Authenticate (one-time):** create an Azure AD app in Partner Center (Account settings → User
+  management → *Azure AD applications*, **Manager** role) to get the **TenantId / ClientId /
+  ClientSecret**; the numeric **SellerId** is in Account settings. Then
+  `msstore reconfigure --tenantId <T> --sellerId <S> --clientId <C> --clientSecret <SECRET>`. Never
+  commit these — use secrets.
+- **Each release:** `.\build-all.ps1 -Sign` (produces `artifacts\store\HostsFileEditor-<flavor>-<arch>.msix`)
+  then `.\publish-store.ps1` — for each edition it does `msstore submission get` → patch packages +
+  the per-edition "What's new" notes → `submission update` → `publish` → `poll`. `-NoCommit` leaves a
+  Draft for a final portal check; `-Edition classic|modern` limits scope.
+- **Open item:** the exact submission-JSON field paths (`applicationPackages` shape / `releaseNotes`
+  location) vary per account. Run `.\publish-store.ps1 -Inspect` once to dump the JSON and fill in the
+  two marked lines in the script before the first real run.
+
 ## Gotchas
 
 - **Warnings are errors.** A change that compiles in isolation can still fail the solution build.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,6 +173,10 @@ Partner Center APIs (preview; free products only, which both editions are).
 - **Verify on the first run:** use `-NoCommit` and confirm in Partner Center that **both** architectures
   uploaded at the new version — `msstore publish -i` takes a directory and the docs describe it as
   finding "the" package, so if only one arch lands, switch to a single `.msixbundle` (`makeappx bundle`).
+- **Reruns / partial failure:** each edition publishes independently — if one fails, the other still
+  completes, a per-edition summary prints, and the script exits non-zero. The Store keeps one pending
+  submission per app, so a rerun **resumes** that app's existing draft; `-Edition <name>` retries just
+  one, `msstore submission delete <productId>` discards a draft.
 
 ## Gotchas
 

--- a/Readme.md
+++ b/Readme.md
@@ -128,11 +128,12 @@ the package, not the exe files inside it, so without `-Sign` the on-demand eleva
 zip. See [docs/signing.md](docs/signing.md) for setup.
 
 To **submit** those Store packages without the Partner Center portal, `publish-store.ps1` scripts the
-submissions via the [Microsoft Store Developer CLI](https://learn.microsoft.com/windows/apps/publish/msstore-dev-cli/overview)
-(`msstore`). Run `.\publish-store.ps1 -InstallTooling` once to install the CLI, authenticate with
-`msstore reconfigure`, then `.\publish-store.ps1` after a signed build to update both editions'
-submissions with the new packages and "What's new" notes. See the *Store release automation* section
-in [CLAUDE.md](CLAUDE.md) for the one-time Partner Center setup.
+submissions via [StoreBroker](https://github.com/microsoft/StoreBroker), Microsoft's PowerShell module
+over the Store submission API. Run `.\publish-store.ps1 -InstallTooling` once to install the module,
+then `.\publish-store.ps1 -NoCommit` after a signed build: for each edition it clones the current Store
+submission, swaps in the new x64+arm64 packages and "What's new" notes, and leaves a Draft to review in
+Partner Center (drop `-NoCommit` to commit). See the *Store release automation* section in
+[CLAUDE.md](CLAUDE.md) for the one-time Azure AD / Partner Center setup.
 
 ### Build Outputs
 

--- a/Readme.md
+++ b/Readme.md
@@ -127,6 +127,13 @@ the package, not the exe files inside it, so without `-Sign` the on-demand eleva
 (Azure Trusted Signing); this also builds SmartScreen reputation for the self-distributed GitHub-release
 zip. See [docs/signing.md](docs/signing.md) for setup.
 
+To **submit** those Store packages without the Partner Center portal, `publish-store.ps1` scripts the
+submissions via the [Microsoft Store Developer CLI](https://learn.microsoft.com/windows/apps/publish/msstore-dev-cli/overview)
+(`msstore`). Run `.\publish-store.ps1 -InstallTooling` once to install the CLI, authenticate with
+`msstore reconfigure`, then `.\publish-store.ps1` after a signed build to update both editions'
+submissions with the new packages and "What's new" notes. See the *Store release automation* section
+in [CLAUDE.md](CLAUDE.md) for the one-time Partner Center setup.
+
 ### Build Outputs
 
 - Built files are automatically copied to the `.\bin` directory after publishing

--- a/publish-store.ps1
+++ b/publish-store.ps1
@@ -1,0 +1,106 @@
+<#
+.SYNOPSIS
+    Automate the Microsoft Store submissions for both Hosts File Editor editions using the
+    Microsoft Store Developer CLI (msstore), instead of the Partner Center portal UI.
+
+.DESCRIPTION
+    Run AFTER `build-all.ps1 -Sign` has produced artifacts\store\*.msix. For each edition this:
+      1. pulls the current submission JSON (`msstore submission get`),
+      2. patches it with the freshly built packages + this release's "What's new" notes,
+      3. pushes it back (`submission update`), publishes (`submission publish`), and polls.
+
+    FIRST-TIME setup:
+      .\publish-store.ps1 -InstallTooling      # winget-installs the .NET 9 runtime + msstore CLI
+      msstore reconfigure --tenantId <T> --sellerId <S> --clientId <C> --clientSecret <SECRET>
+      .\publish-store.ps1 -Inspect             # dump the submission JSON, then fill in the two
+                                               #   marked field paths below for your account.
+
+    See the "Store release automation" section in CLAUDE.md for the full walkthrough (creating the
+    Partner Center Azure AD app to get the tenant/client/seller/secret values).
+
+.EXAMPLE
+    .\publish-store.ps1 -InstallTooling
+.EXAMPLE
+    .\build-all.ps1 -Sign; .\publish-store.ps1            # build+sign, then submit both editions
+.EXAMPLE
+    .\publish-store.ps1 -Edition modern -NoCommit         # update the modern draft, don't publish
+#>
+[CmdletBinding()]
+param(
+    [switch]$InstallTooling,                    # winget-install the .NET 9 runtime + msstore CLI, then exit
+    [switch]$Inspect,                           # dump the current submission JSON and exit
+    [switch]$NoCommit,                          # update the draft but DON'T publish (review in the portal)
+    [ValidateSet('classic', 'modern', 'both')]
+    [string]$Edition = 'both',
+    [string]$ClassicProductId = '9NF73PSPK332',   # https://apps.microsoft.com/detail/9NF73PSPK332
+    [string]$ModernProductId  = '9NBQWCDXGF9R'    # https://apps.microsoft.com/detail/9NBQWCDXGF9R
+)
+$ErrorActionPreference = 'Stop'
+$storeDir = Join-Path $PSScriptRoot 'artifacts\store'
+
+# ---- Per-release "What's new" copy (edit each release) ----
+$notes = @{
+    classic = @'
+Performance and reliability update:
+- Much faster on very large hosts files - async load, ~3x faster parser, and bulk edits that used to freeze now finish in milliseconds.
+- Smaller, faster install.
+- Fixed a crash when sorting by a column header; fixed a Select-All/Delete data-loss case.
+- Tailscale/MagicDNS names ending in a dot (host.tailnet.ts.net.) now parse correctly.
+'@
+    modern = @'
+Performance and polish update:
+- Much faster on very large hosts files - async load, ~3x faster parser, instant bulk edits.
+- New status bar (line + host-entry counts); no more column flicker; selection kept across Check/Uncheck & Duplicate.
+- Tailscale/MagicDNS names ending in a dot now parse correctly.
+'@
+}
+
+function Test-Tool([string]$Name) { [bool](Get-Command $Name -ErrorAction SilentlyContinue) }
+
+function Install-Tooling {
+    if (-not (Test-Tool winget)) {
+        throw "winget not found. Install 'App Installer' from the Microsoft Store, then re-run; or download msstore directly from https://aka.ms/msstoredevcli/releases."
+    }
+    $wingetArgs = '--accept-source-agreements', '--accept-package-agreements', '--disable-interactivity'
+    Write-Host '==> Installing .NET 9 Desktop Runtime (msstore prerequisite)' -ForegroundColor Cyan
+    & winget install --id Microsoft.DotNet.DesktopRuntime.9 @wingetArgs
+    Write-Host '==> Installing Microsoft Store Developer CLI' -ForegroundColor Cyan
+    & winget install 'Microsoft Store Developer CLI' @wingetArgs
+    Write-Host "Done. Open a NEW shell so 'msstore' is on PATH, then run: msstore reconfigure ..." -ForegroundColor Green
+}
+
+if ($InstallTooling) { Install-Tooling; return }
+
+if (-not (Test-Tool msstore)) {
+    throw "msstore CLI not found. Run '.\publish-store.ps1 -InstallTooling' once (installs it + the .NET 9 runtime via winget), then 'msstore reconfigure ...'. See CLAUDE.md > Store release automation."
+}
+
+function Publish-Edition {
+    param([string]$Name, [string]$ProductId)
+
+    $packages = @(Get-ChildItem (Join-Path $storeDir "HostsFileEditor-$Name-*.msix") -ErrorAction SilentlyContinue | Select-Object -ExpandProperty FullName)
+    if (-not $packages) { throw "No packages found: $storeDir\HostsFileEditor-$Name-*.msix (run .\build-all.ps1 -Sign first)." }
+    Write-Host "==> $Name ($ProductId): $($packages.Count) package(s)" -ForegroundColor Cyan
+    $packages | ForEach-Object { Write-Host "     $_" -ForegroundColor DarkGray }
+
+    $current = (& msstore submission get $ProductId | Out-String)
+    if ($Inspect) { $current; return }
+
+    $sub = $current | ConvertFrom-Json -Depth 50
+
+    # --- CONFIRM THESE TWO FIELD PATHS against `-Inspect` output the first time, then uncomment ---
+    #     (the exact schema — applicationPackages shape / releaseNotes location — varies per account)
+    # $sub.applicationPackages = @($packages | ForEach-Object { @{ fileName = (Split-Path $_ -Leaf); fileStatus = 'PendingUpload'; localFilePath = $_ } })
+    # $sub.listings.'en-us'.baseListing.releaseNotes = $notes[$Name]
+    throw "Fill in the two field paths above (use -Inspect to see the JSON), then remove this line. See CLAUDE.md > Store release automation."
+
+    $updated = $sub | ConvertTo-Json -Depth 50
+    & msstore submission update $ProductId $updated
+    if ($NoCommit) { Write-Host '  draft updated (not published).' -ForegroundColor Yellow; return }
+    & msstore submission publish $ProductId
+    & msstore submission poll $ProductId
+}
+
+if ($Edition -in 'classic', 'both') { Publish-Edition -Name 'classic' -ProductId $ClassicProductId }
+if ($Edition -in 'modern', 'both') { Publish-Edition -Name 'modern' -ProductId $ModernProductId }
+Write-Host 'Done.' -ForegroundColor Green

--- a/publish-store.ps1
+++ b/publish-store.ps1
@@ -65,17 +65,20 @@ $storeDir = Join-Path $PSScriptRoot 'artifacts\store'
 # ---- Per-release "What's new" copy (edit each release) ----
 $notes = @{
     classic = @'
-Performance and reliability update:
-- Much faster on very large hosts files - async load, ~3x faster parser, and bulk edits that used to freeze now finish in milliseconds.
-- Smaller, faster install.
-- Fixed a crash when sorting by a column header; fixed a Select-All/Delete data-loss case.
-- Tailscale/MagicDNS names ending in a dot (host.tailnet.ts.net.) now parse correctly.
+Feature update (v1.5.0):
+- Command line for scripts: switch presets, enable/disable, import, and merge (hfe on PATH; run "hfe help").
+- Taskbar Jump List: right-click the app icon to open any saved preset directly.
+- File > Merge combines another hosts file into the current one, skipping duplicates (undoable).
+- Global shortcut (default Ctrl+Shift+H, configurable) hides/restores the window from the tray.
+- IP column now sorts numerically; text filter is now case-insensitive; auto-ping shows a progress indicator and flags failed entries.
 '@
     modern = @'
-Performance and polish update:
-- Much faster on very large hosts files - async load, ~3x faster parser, instant bulk edits.
-- New status bar (line + host-entry counts); no more column flicker; selection kept across Check/Uncheck & Duplicate.
-- Tailscale/MagicDNS names ending in a dot now parse correctly.
+Feature update (v1.2.0):
+- Command line for scripts: switch presets, enable/disable, import, and merge (hfe on PATH; run "hfe help").
+- Taskbar Jump List: right-click the app icon to open any saved preset directly.
+- File > Merge combines another hosts file into the current one, skipping duplicates (undoable).
+- New Sort options next to the filter; the IP column sorts numerically.
+- Auto-ping shows a progress indicator and marks failed entries with an error badge.
 '@
 }
 

--- a/publish-store.ps1
+++ b/publish-store.ps1
@@ -1,45 +1,61 @@
 <#
 .SYNOPSIS
-    Automate the Microsoft Store submissions for both Hosts File Editor editions using the
-    Microsoft Store Developer CLI (msstore), instead of the Partner Center portal UI.
+    Automate the Microsoft Store submissions for both Hosts File Editor editions with StoreBroker
+    (Microsoft's PowerShell module over the Store submission REST API), instead of the Partner
+    Center portal UI.
 
 .DESCRIPTION
-    Run AFTER `build-all.ps1 -Sign` has produced artifacts\store\*.msix. For each edition this:
-      1. stages that edition's x64+arm64 packages and uploads them into a DRAFT submission
-         (`msstore publish -i <dir> --noCommit`),
-      2. patches the draft's "What's new" notes (every listing locale),
-      3. commits (`submission publish`) and polls — unless -NoCommit.
+    Run AFTER `build-all.ps1 -Sign` has produced artifacts\store\HostsFileEditor-<edition>-<arch>.msix.
+    For each edition this:
+      1. clones the app's current published submission into a fresh pending one
+         (New-ApplicationSubmission -Force),
+      2. swaps in this release's packages (existing -> PendingDelete, the new x64+arm64 msix ->
+         PendingUpload) and sets the "What's new" notes on every listing locale,
+      3. pushes the patched submission (Set-ApplicationSubmission), uploads the packages .zip
+         (Set-SubmissionPackage), and commits (Complete-ApplicationSubmission) - unless -NoCommit.
+
+    Why StoreBroker and not the msstore CLI: msstore's `publish` builds a project of a recognized
+    type; it can't take our pre-built, externally-signed MSIX and push them to an existing app by id.
+    StoreBroker is purpose-built for exactly that - upload prepared packages + metadata to an
+    existing app over the submission API. Cloning the published submission means the rich listing
+    (description, screenshots, etc.) is preserved; only the packages and release notes change.
 
     FIRST-TIME setup (see CLAUDE.md > Store release automation for the full walkthrough):
-      .\publish-store.ps1 -InstallTooling      # winget-installs the .NET 9 runtime + msstore CLI
-      msstore                                  # interactive first-run: sign in with your ENTRA ID
-                                               #   account (NOT your MSA); resolves your Seller Id.
-      msstore info                             # confirm the config
+      .\publish-store.ps1 -InstallTooling      # installs the StoreBroker PowerShell module
+      # Create an Azure AD app in Partner Center (Account settings > User management > Azure AD
+      # applications, Manager role) to get the TenantId / ClientId / a client secret (a "Key").
 
-    RECOMMENDED first real run: use -NoCommit and then review the Draft in Partner Center - in
-    particular confirm BOTH architectures (x64 + arm64) uploaded at the new version. `msstore publish`
-    takes a directory; if it only picks up one package, tell the maintainer (fallback: a .msixbundle).
+    AUTH each run (the script calls Set-StoreBrokerAuthentication for you): supply the credentials
+    via -TenantId / -ClientId / -ClientSecret, or the environment variables STOREBROKER_TENANTID /
+    STOREBROKER_CLIENTID / STOREBROKER_CLIENTSECRET, otherwise you are prompted. The secret is only
+    ever held as a SecureString and is never written to disk by this script. Tenant and Client ids
+    are not secrets; the secret is - keep it out of source control and shell history.
 
-    Each edition publishes INDEPENDENTLY: if one fails (upload/update/publish/poll), the other still
-    completes, a per-edition summary prints, and the script exits non-zero. The Store keeps a single
-    pending submission per app, so a rerun RESUMES that app's existing draft (it does not stack a
-    second) - retry only the failed edition with -Edition <name>, or `msstore submission delete
-    <productId>` to discard a draft and start over.
+    RECOMMENDED first real run: -NoCommit, then review the Draft in Partner Center - confirm BOTH
+    architectures (x64 + arm64) uploaded at the new version before you commit it there.
+
+    Each edition publishes INDEPENDENTLY: if one fails, the other still completes, a per-edition
+    summary prints, and the script exits non-zero. New-ApplicationSubmission -Force means a rerun
+    discards any half-built pending submission and re-clones from the published one, so retrying is
+    safe - retry just the failed edition with -Edition <name>.
 
 .EXAMPLE
     .\publish-store.ps1 -InstallTooling
 .EXAMPLE
-    .\build-all.ps1 -Sign; .\publish-store.ps1 -NoCommit     # build+sign, stage drafts, review in portal
+    .\build-all.ps1 -Sign; .\publish-store.ps1 -NoCommit    # build+sign, stage drafts, review in portal
 .EXAMPLE
-    .\publish-store.ps1 -Edition modern                      # publish only the modern edition, commit
+    .\publish-store.ps1 -Edition modern                     # publish only the modern edition, commit
 #>
 [CmdletBinding()]
 param(
-    [switch]$InstallTooling,                    # winget-install the .NET 9 runtime + msstore CLI, then exit
-    [switch]$Inspect,                           # dump the current submission JSON and exit
-    [switch]$NoCommit,                          # upload + set notes into a Draft, but DON'T publish
+    [switch]$InstallTooling,                    # install the StoreBroker module, then exit
+    [switch]$Inspect,                           # dump each edition's current submission JSON and exit
+    [switch]$NoCommit,                          # upload packages + set notes into a Draft, but DON'T commit
     [ValidateSet('classic', 'modern', 'both')]
     [string]$Edition = 'both',
+    [string]$TenantId,                          # Partner Center Azure AD tenant id (or $env:STOREBROKER_TENANTID)
+    [string]$ClientId,                          # Azure AD app (client) id            (or $env:STOREBROKER_CLIENTID)
+    [securestring]$ClientSecret,                # Azure AD client secret              (or $env:STOREBROKER_CLIENTSECRET)
     [string]$ClassicProductId = '9NF73PSPK332',   # https://apps.microsoft.com/detail/9NF73PSPK332
     [string]$ModernProductId  = '9NBQWCDXGF9R'    # https://apps.microsoft.com/detail/9NBQWCDXGF9R
 )
@@ -63,78 +79,168 @@ Performance and polish update:
 '@
 }
 
-function Test-Tool([string]$Name) { [bool](Get-Command $Name -ErrorAction SilentlyContinue) }
-
 function Install-Tooling {
-    if (-not (Test-Tool winget)) {
-        throw "winget not found. Install 'App Installer' from the Microsoft Store, then re-run; or download msstore directly from https://aka.ms/msstoredevcli/releases."
-    }
-    $wingetArgs = '--accept-source-agreements', '--accept-package-agreements', '--disable-interactivity'
-    Write-Host '==> Installing .NET 9 Desktop Runtime (msstore prerequisite)' -ForegroundColor Cyan
-    & winget install --id Microsoft.DotNet.DesktopRuntime.9 @wingetArgs
-    Write-Host '==> Installing Microsoft Store Developer CLI' -ForegroundColor Cyan
-    & winget install 'Microsoft Store Developer CLI' @wingetArgs
-    Write-Host "Done. Open a NEW shell so 'msstore' is on PATH, then run: msstore   (sign in with your Entra ID account)." -ForegroundColor Green
+    Write-Host '==> Installing the StoreBroker PowerShell module (CurrentUser scope)' -ForegroundColor Cyan
+    Install-Module -Name StoreBroker -Scope CurrentUser -Force -AllowClobber
+    $v = (Get-Module -ListAvailable StoreBroker | Sort-Object Version -Descending | Select-Object -First 1).Version
+    Write-Host "Done. StoreBroker $v installed." -ForegroundColor Green
+    Write-Host 'Next: set STOREBROKER_TENANTID / STOREBROKER_CLIENTID / STOREBROKER_CLIENTSECRET (or pass' -ForegroundColor Green
+    Write-Host '      -TenantId / -ClientId / -ClientSecret), then run this script after build-all.ps1 -Sign.' -ForegroundColor Green
 }
 
 if ($InstallTooling) { Install-Tooling; return }
 
-if (-not (Test-Tool msstore)) {
-    throw "msstore CLI not found. Run '.\publish-store.ps1 -InstallTooling' once, then 'msstore' to sign in. See CLAUDE.md > Store release automation."
+if (-not (Get-Module -ListAvailable StoreBroker)) {
+    throw "StoreBroker module not found. Run '.\publish-store.ps1 -InstallTooling' once. See CLAUDE.md > Store release automation."
+}
+Import-Module StoreBroker -ErrorAction Stop
+
+# StoreBroker's opt-out telemetry POSTs to App Insights fail with a 400 on this account and spew
+# alarming (but entirely non-fatal) errors into the log on every API call. Turn it off.
+$global:SBDisableTelemetry = $true
+$global:SBSuppressTelemetryReminder = $true
+
+# Resolve credentials (param > env var > prompt) and authenticate. The secret stays a SecureString.
+function Connect-Store {
+    $tenant = if ($TenantId) { $TenantId } elseif ($env:STOREBROKER_TENANTID) { $env:STOREBROKER_TENANTID } else { Read-Host 'Partner Center TenantId (GUID)' }
+    $client = if ($ClientId) { $ClientId } elseif ($env:STOREBROKER_CLIENTID) { $env:STOREBROKER_CLIENTID } else { Read-Host 'Azure AD ClientId (GUID)' }
+    $secret =
+        if     ($ClientSecret)                    { $ClientSecret }
+        elseif ($env:STOREBROKER_CLIENTSECRET)    { ConvertTo-SecureString $env:STOREBROKER_CLIENTSECRET -AsPlainText -Force }
+        else                                      { Read-Host 'Azure AD client secret' -AsSecureString }
+    if (-not $tenant -or -not $client -or -not $secret) { throw 'Missing TenantId / ClientId / ClientSecret for Partner Center authentication.' }
+    $cred = [System.Management.Automation.PSCredential]::new($client, $secret)
+    Set-StoreBrokerAuthentication -TenantId $tenant -Credential $cred | Out-Null
+    Write-Host "Authenticated to Partner Center (tenant $tenant)." -ForegroundColor DarkGray
+}
+
+# Read Identity/@Version straight out of an msix (a zip) so the summary shows what's being uploaded.
+function Get-MsixVersion([string]$Path) {
+    try {
+        $zip = [System.IO.Compression.ZipFile]::OpenRead($Path)
+        try {
+            $entry = $zip.Entries | Where-Object { $_.FullName -eq 'AppxManifest.xml' } | Select-Object -First 1
+            if (-not $entry) { return '?' }
+            $sr = [System.IO.StreamReader]::new($entry.Open())
+            try { $xml = [xml]$sr.ReadToEnd() } finally { $sr.Dispose() }
+            return $xml.Package.Identity.Version
+        } finally { $zip.Dispose() }
+    } catch { return '?' }
+}
+
+function Get-EditionPackages([string]$Name) {
+    $pkgs = @(Get-ChildItem (Join-Path $storeDir "HostsFileEditor-$Name-*.msix") -ErrorAction SilentlyContinue)
+    if (-not $pkgs) { throw "No packages found: $storeDir\HostsFileEditor-$Name-*.msix (run .\build-all.ps1 -Sign first)." }
+    $pkgs
+}
+
+# The Store submission API (manage.devcenter.microsoft.com, behind Azure Front Door) intermittently
+# times out / returns 502-504. Retry those transient failures with linear backoff; let real errors
+# (400/401/409/...) surface immediately. Every call here is safe to retry: New-ApplicationSubmission
+# -Force re-clones cleanly, and Set-* / upload are idempotent (same body / same blob).
+function Invoke-WithRetry {
+    param([Parameter(Mandatory)][scriptblock]$Action, [string]$What = 'call', [int]$MaxAttempts = 5, [int]$BaseDelaySec = 6)
+    for ($attempt = 1; ; $attempt++) {
+        try { return & $Action }
+        catch {
+            $m = ($_.Exception.Message -split "`n")[0]
+            $transient = $m -match '50[234]|OriginTimeout|Gateway|Service unavailable|timed? ?out|temporarily'
+            if (-not $transient -or $attempt -ge $MaxAttempts) { throw }
+            $delay = $BaseDelaySec * $attempt
+            Write-Host "    $What transient failure (attempt $attempt/$MaxAttempts): $m" -ForegroundColor DarkYellow
+            Write-Host "    retrying in ${delay}s..." -ForegroundColor DarkYellow
+            Start-Sleep -Seconds $delay
+        }
+    }
 }
 
 function Publish-Edition {
     param([string]$Name, [string]$ProductId)
 
-    $packages = @(Get-ChildItem (Join-Path $storeDir "HostsFileEditor-$Name-*.msix") -ErrorAction SilentlyContinue)
-    if (-not $packages) { throw "No packages found: $storeDir\HostsFileEditor-$Name-*.msix (run .\build-all.ps1 -Sign first)." }
+    $packages = Get-EditionPackages $Name
     Write-Host "==> $Name ($ProductId): $($packages.Count) package(s)" -ForegroundColor Cyan
-    $packages | ForEach-Object { Write-Host "     $($_.Name)" -ForegroundColor DarkGray }
+    $packages | ForEach-Object { Write-Host "     $($_.Name)  [v$(Get-MsixVersion $_.FullName)]" -ForegroundColor DarkGray }
 
-    # Stage just THIS edition's packages so `msstore publish -i <dir>` uploads only its arches
-    # (artifacts\store\ also holds the other edition's packages).
-    $stage = Join-Path $storeDir "_upload-$Name"
-    if (Test-Path $stage) { Remove-Item $stage -Recurse -Force }
-    New-Item -ItemType Directory -Path $stage | Out-Null
-    $packages | Copy-Item -Destination $stage
+    # 1. Clone the current published submission into a fresh pending one. -Force first discards any
+    #    half-built pending submission, so reruns re-clone cleanly from what's live.
+    Write-Host '  cloning current published submission...' -ForegroundColor DarkGray
+    $sub = Invoke-WithRetry -What 'clone submission' { New-ApplicationSubmission -AppId $ProductId -Force -NoStatus }
+    $uploadUrl = $sub.fileUploadUrl
 
-    # 1. Upload the packages into a DRAFT (create/clone a pending submission, don't commit yet).
-    Write-Host '  uploading packages into a draft submission...' -ForegroundColor DarkGray
-    & msstore publish -i $stage -id $ProductId --noCommit
-    if ($LASTEXITCODE) { throw "msstore publish failed for $Name (exit $LASTEXITCODE)." }
+    # 2a. Swap packages: mark every existing package for deletion, add the new x64+arm64 msix. The
+    #     Store fills in version/architecture/languages from each uploaded package during processing,
+    #     so a new entry needs only its file name and PendingUpload status.
+    $existing = @($sub.applicationPackages)
+    foreach ($p in $existing) { $p.fileStatus = 'PendingDelete' }
+    $added = $packages | ForEach-Object { [pscustomobject]@{ fileName = $_.Name; fileStatus = 'PendingUpload' } }
+    $sub.applicationPackages = @($existing) + @($added)
 
-    # 2. Set this release's "What's new" on the draft, for every listing locale.
-    $sub = (& msstore submission get $ProductId | Out-String) | ConvertFrom-Json -Depth 60
-    foreach ($locale in @($sub.Listings.PSObject.Properties.Name)) {
-        if ($sub.Listings.$locale.BaseListing) { $sub.Listings.$locale.BaseListing.ReleaseNotes = $notes[$Name] }
+    # 2b. Set this release's "What's new" on every listing locale that has a base listing.
+    foreach ($prop in @($sub.listings.PSObject.Properties)) {
+        $base = $prop.Value.baseListing
+        if ($null -ne $base) {
+            if ($base.PSObject.Properties.Name -contains 'releaseNotes') { $base.releaseNotes = $notes[$Name] }
+            else { $base | Add-Member -NotePropertyName releaseNotes -NotePropertyValue $notes[$Name] -Force }
+        }
     }
-    & msstore submission update $ProductId ($sub | ConvertTo-Json -Depth 60 -Compress)
-    if ($LASTEXITCODE) { throw "msstore submission update failed for $Name (exit $LASTEXITCODE)." }
 
-    # 3. Commit + poll (unless leaving a Draft for a manual portal review).
-    if ($NoCommit) { Write-Host '  draft updated (packages + notes); NOT published - review in Partner Center.' -ForegroundColor Yellow; return }
-    & msstore submission publish $ProductId
-    & msstore submission poll $ProductId
+    # 3. Push the patched submission metadata, then upload the packages as a single zip (each msix at
+    #    the zip root, its name matching the fileName set above).
+    Write-Host '  updating submission metadata (packages + notes)...' -ForegroundColor DarkGray
+    Invoke-WithRetry -What 'update submission' { Set-ApplicationSubmission -AppId $ProductId -UpdatedSubmission $sub -NoStatus } | Out-Null
+
+    $zip = Join-Path $storeDir "_upload-$Name.zip"
+    if (Test-Path $zip) { Remove-Item $zip -Force }
+    try {
+        Compress-Archive -Path $packages.FullName -DestinationPath $zip -Force
+        Write-Host "  uploading packages ($([math]::Round((Get-Item $zip).Length / 1MB, 1)) MB)..." -ForegroundColor DarkGray
+        Invoke-WithRetry -What 'upload packages' { Set-SubmissionPackage -PackagePath $zip -UploadUrl $uploadUrl -NoStatus }
+    }
+    finally { Remove-Item $zip -Force -ErrorAction SilentlyContinue }
+
+    # 4. Commit + report status once (unless leaving a Draft for a manual portal review).
+    if ($NoCommit) {
+        Write-Host "  draft ready (submission $($sub.id)); NOT committed - review in Partner Center." -ForegroundColor Yellow
+        return
+    }
+    Write-Host '  committing submission...' -ForegroundColor DarkGray
+    Invoke-WithRetry -What 'commit submission' { Complete-ApplicationSubmission -AppId $ProductId -SubmissionId $sub.id -NoStatus }
+    try {
+        $st = Invoke-WithRetry -What 'get status' { Get-ApplicationSubmissionStatus -AppId $ProductId -SubmissionId $sub.id -NoStatus }
+        Write-Host "  committed; certification status: $($st.status)" -ForegroundColor DarkGray
+    } catch { }
+}
+
+function Show-CurrentSubmission {
+    param([string]$Name, [string]$ProductId)
+    $app = Invoke-WithRetry -What 'get application' { Get-Application -AppId $ProductId -NoStatus }
+    Write-Host "===== $Name ($ProductId) - '$($app.primaryName)' =====" -ForegroundColor Cyan
+    $subId = if ($app.pendingApplicationSubmission)      { $app.pendingApplicationSubmission.id }
+             elseif ($app.lastPublishedApplicationSubmission) { $app.lastPublishedApplicationSubmission.id }
+             else { $null }
+    if (-not $subId) { Write-Host '  (no submission found)' -ForegroundColor DarkGray; return }
+    $kind = if ($app.pendingApplicationSubmission) { 'pending' } else { 'lastPublished' }
+    Write-Host "  $kind submission $subId" -ForegroundColor DarkGray
+    Invoke-WithRetry -What 'get submission' { Get-ApplicationSubmission -AppId $ProductId -SubmissionId $subId -NoStatus } | ConvertTo-Json -Depth 20
 }
 
 $targets = @()
 if ($Edition -in 'classic', 'both') { $targets += @{ Name = 'classic'; ProductId = $ClassicProductId } }
-if ($Edition -in 'modern', 'both') { $targets += @{ Name = 'modern'; ProductId = $ModernProductId } }
+if ($Edition -in 'modern', 'both')  { $targets += @{ Name = 'modern';  ProductId = $ModernProductId } }
+
+Connect-Store
 
 if ($Inspect) {
-    foreach ($t in $targets) {
-        Write-Host "===== $($t.Name) ($($t.ProductId)) =====" -ForegroundColor Cyan
-        & msstore submission get $t.ProductId
-    }
+    foreach ($t in $targets) { Show-CurrentSubmission -Name $t.Name -ProductId $t.ProductId }
     return
 }
 
-# Publish each edition INDEPENDENTLY: a failure in one (upload/update/publish/poll) must not abort the
-# other or hide that it already submitted. Collect a per-edition result and exit non-zero if any failed.
+# Publish each edition INDEPENDENTLY: a failure in one must not abort the other or hide that it
+# already submitted. Collect a per-edition result and exit non-zero if any failed.
 $results = foreach ($t in $targets) {
     try {
         Publish-Edition -Name $t.Name -ProductId $t.ProductId
-        [pscustomobject]@{ Edition = $t.Name; ProductId = $t.ProductId; Result = $(if ($NoCommit) { 'Draft updated (not published)' } else { 'Published' }) }
+        [pscustomobject]@{ Edition = $t.Name; ProductId = $t.ProductId; Result = $(if ($NoCommit) { 'Draft ready (not committed)' } else { 'Committed' }) }
     }
     catch {
         Write-Host "  FAILED ($($t.Name)): $($_.Exception.Message)" -ForegroundColor Red
@@ -146,10 +252,8 @@ Write-Host "`n=== Per-edition summary ===" -ForegroundColor Cyan
 ($results | Format-Table Edition, ProductId, Result -AutoSize | Out-String).TrimEnd() | Write-Host
 
 if (@($results | Where-Object { $_.Result -like 'FAILED*' }).Count) {
-    # The Store keeps ONE pending submission per app, so a rerun RESUMES that app's existing draft
-    # (it doesn't stack a second). Retry just the failed edition with -Edition <name>; the already-
-    # submitted edition needs nothing. To discard a bad draft and start fresh: msstore submission delete <productId>.
-    Write-Host "One or more editions did not complete. Re-run with -Edition <name> to retry just that one." -ForegroundColor Yellow
+    # New-ApplicationSubmission -Force means a rerun re-clones cleanly, so just retry the failed one.
+    Write-Host 'One or more editions did not complete. Re-run with -Edition <name> to retry just that one.' -ForegroundColor Yellow
     exit 1
 }
 Write-Host 'Done.' -ForegroundColor Green

--- a/publish-store.ps1
+++ b/publish-store.ps1
@@ -20,6 +20,12 @@
     particular confirm BOTH architectures (x64 + arm64) uploaded at the new version. `msstore publish`
     takes a directory; if it only picks up one package, tell the maintainer (fallback: a .msixbundle).
 
+    Each edition publishes INDEPENDENTLY: if one fails (upload/update/publish/poll), the other still
+    completes, a per-edition summary prints, and the script exits non-zero. The Store keeps a single
+    pending submission per app, so a rerun RESUMES that app's existing draft (it does not stack a
+    second) - retry only the failed edition with -Edition <name>, or `msstore submission delete
+    <productId>` to discard a draft and start over.
+
 .EXAMPLE
     .\publish-store.ps1 -InstallTooling
 .EXAMPLE
@@ -80,8 +86,6 @@ if (-not (Test-Tool msstore)) {
 function Publish-Edition {
     param([string]$Name, [string]$ProductId)
 
-    if ($Inspect) { & msstore submission get $ProductId; return }
-
     $packages = @(Get-ChildItem (Join-Path $storeDir "HostsFileEditor-$Name-*.msix") -ErrorAction SilentlyContinue)
     if (-not $packages) { throw "No packages found: $storeDir\HostsFileEditor-$Name-*.msix (run .\build-all.ps1 -Sign first)." }
     Write-Host "==> $Name ($ProductId): $($packages.Count) package(s)" -ForegroundColor Cyan
@@ -113,6 +117,39 @@ function Publish-Edition {
     & msstore submission poll $ProductId
 }
 
-if ($Edition -in 'classic', 'both') { Publish-Edition -Name 'classic' -ProductId $ClassicProductId }
-if ($Edition -in 'modern', 'both') { Publish-Edition -Name 'modern' -ProductId $ModernProductId }
+$targets = @()
+if ($Edition -in 'classic', 'both') { $targets += @{ Name = 'classic'; ProductId = $ClassicProductId } }
+if ($Edition -in 'modern', 'both') { $targets += @{ Name = 'modern'; ProductId = $ModernProductId } }
+
+if ($Inspect) {
+    foreach ($t in $targets) {
+        Write-Host "===== $($t.Name) ($($t.ProductId)) =====" -ForegroundColor Cyan
+        & msstore submission get $t.ProductId
+    }
+    return
+}
+
+# Publish each edition INDEPENDENTLY: a failure in one (upload/update/publish/poll) must not abort the
+# other or hide that it already submitted. Collect a per-edition result and exit non-zero if any failed.
+$results = foreach ($t in $targets) {
+    try {
+        Publish-Edition -Name $t.Name -ProductId $t.ProductId
+        [pscustomobject]@{ Edition = $t.Name; ProductId = $t.ProductId; Result = $(if ($NoCommit) { 'Draft updated (not published)' } else { 'Published' }) }
+    }
+    catch {
+        Write-Host "  FAILED ($($t.Name)): $($_.Exception.Message)" -ForegroundColor Red
+        [pscustomobject]@{ Edition = $t.Name; ProductId = $t.ProductId; Result = "FAILED - $($_.Exception.Message)" }
+    }
+}
+
+Write-Host "`n=== Per-edition summary ===" -ForegroundColor Cyan
+($results | Format-Table Edition, ProductId, Result -AutoSize | Out-String).TrimEnd() | Write-Host
+
+if (@($results | Where-Object { $_.Result -like 'FAILED*' }).Count) {
+    # The Store keeps ONE pending submission per app, so a rerun RESUMES that app's existing draft
+    # (it doesn't stack a second). Retry just the failed edition with -Edition <name>; the already-
+    # submitted edition needs nothing. To discard a bad draft and start fresh: msstore submission delete <productId>.
+    Write-Host "One or more editions did not complete. Re-run with -Edition <name> to retry just that one." -ForegroundColor Yellow
+    exit 1
+}
 Write-Host 'Done.' -ForegroundColor Green

--- a/publish-store.ps1
+++ b/publish-store.ps1
@@ -5,31 +5,33 @@
 
 .DESCRIPTION
     Run AFTER `build-all.ps1 -Sign` has produced artifacts\store\*.msix. For each edition this:
-      1. pulls the current submission JSON (`msstore submission get`),
-      2. patches it with the freshly built packages + this release's "What's new" notes,
-      3. pushes it back (`submission update`), publishes (`submission publish`), and polls.
+      1. stages that edition's x64+arm64 packages and uploads them into a DRAFT submission
+         (`msstore publish -i <dir> --noCommit`),
+      2. patches the draft's "What's new" notes (every listing locale),
+      3. commits (`submission publish`) and polls — unless -NoCommit.
 
-    FIRST-TIME setup:
+    FIRST-TIME setup (see CLAUDE.md > Store release automation for the full walkthrough):
       .\publish-store.ps1 -InstallTooling      # winget-installs the .NET 9 runtime + msstore CLI
-      msstore reconfigure --tenantId <T> --sellerId <S> --clientId <C> --clientSecret <SECRET>
-      .\publish-store.ps1 -Inspect             # dump the submission JSON, then fill in the two
-                                               #   marked field paths below for your account.
+      msstore                                  # interactive first-run: sign in with your ENTRA ID
+                                               #   account (NOT your MSA); resolves your Seller Id.
+      msstore info                             # confirm the config
 
-    See the "Store release automation" section in CLAUDE.md for the full walkthrough (creating the
-    Partner Center Azure AD app to get the tenant/client/seller/secret values).
+    RECOMMENDED first real run: use -NoCommit and then review the Draft in Partner Center - in
+    particular confirm BOTH architectures (x64 + arm64) uploaded at the new version. `msstore publish`
+    takes a directory; if it only picks up one package, tell the maintainer (fallback: a .msixbundle).
 
 .EXAMPLE
     .\publish-store.ps1 -InstallTooling
 .EXAMPLE
-    .\build-all.ps1 -Sign; .\publish-store.ps1            # build+sign, then submit both editions
+    .\build-all.ps1 -Sign; .\publish-store.ps1 -NoCommit     # build+sign, stage drafts, review in portal
 .EXAMPLE
-    .\publish-store.ps1 -Edition modern -NoCommit         # update the modern draft, don't publish
+    .\publish-store.ps1 -Edition modern                      # publish only the modern edition, commit
 #>
 [CmdletBinding()]
 param(
     [switch]$InstallTooling,                    # winget-install the .NET 9 runtime + msstore CLI, then exit
     [switch]$Inspect,                           # dump the current submission JSON and exit
-    [switch]$NoCommit,                          # update the draft but DON'T publish (review in the portal)
+    [switch]$NoCommit,                          # upload + set notes into a Draft, but DON'T publish
     [ValidateSet('classic', 'modern', 'both')]
     [string]$Edition = 'both',
     [string]$ClassicProductId = '9NF73PSPK332',   # https://apps.microsoft.com/detail/9NF73PSPK332
@@ -66,37 +68,47 @@ function Install-Tooling {
     & winget install --id Microsoft.DotNet.DesktopRuntime.9 @wingetArgs
     Write-Host '==> Installing Microsoft Store Developer CLI' -ForegroundColor Cyan
     & winget install 'Microsoft Store Developer CLI' @wingetArgs
-    Write-Host "Done. Open a NEW shell so 'msstore' is on PATH, then run: msstore reconfigure ..." -ForegroundColor Green
+    Write-Host "Done. Open a NEW shell so 'msstore' is on PATH, then run: msstore   (sign in with your Entra ID account)." -ForegroundColor Green
 }
 
 if ($InstallTooling) { Install-Tooling; return }
 
 if (-not (Test-Tool msstore)) {
-    throw "msstore CLI not found. Run '.\publish-store.ps1 -InstallTooling' once (installs it + the .NET 9 runtime via winget), then 'msstore reconfigure ...'. See CLAUDE.md > Store release automation."
+    throw "msstore CLI not found. Run '.\publish-store.ps1 -InstallTooling' once, then 'msstore' to sign in. See CLAUDE.md > Store release automation."
 }
 
 function Publish-Edition {
     param([string]$Name, [string]$ProductId)
 
-    $packages = @(Get-ChildItem (Join-Path $storeDir "HostsFileEditor-$Name-*.msix") -ErrorAction SilentlyContinue | Select-Object -ExpandProperty FullName)
+    if ($Inspect) { & msstore submission get $ProductId; return }
+
+    $packages = @(Get-ChildItem (Join-Path $storeDir "HostsFileEditor-$Name-*.msix") -ErrorAction SilentlyContinue)
     if (-not $packages) { throw "No packages found: $storeDir\HostsFileEditor-$Name-*.msix (run .\build-all.ps1 -Sign first)." }
     Write-Host "==> $Name ($ProductId): $($packages.Count) package(s)" -ForegroundColor Cyan
-    $packages | ForEach-Object { Write-Host "     $_" -ForegroundColor DarkGray }
+    $packages | ForEach-Object { Write-Host "     $($_.Name)" -ForegroundColor DarkGray }
 
-    $current = (& msstore submission get $ProductId | Out-String)
-    if ($Inspect) { $current; return }
+    # Stage just THIS edition's packages so `msstore publish -i <dir>` uploads only its arches
+    # (artifacts\store\ also holds the other edition's packages).
+    $stage = Join-Path $storeDir "_upload-$Name"
+    if (Test-Path $stage) { Remove-Item $stage -Recurse -Force }
+    New-Item -ItemType Directory -Path $stage | Out-Null
+    $packages | Copy-Item -Destination $stage
 
-    $sub = $current | ConvertFrom-Json -Depth 50
+    # 1. Upload the packages into a DRAFT (create/clone a pending submission, don't commit yet).
+    Write-Host '  uploading packages into a draft submission...' -ForegroundColor DarkGray
+    & msstore publish -i $stage -id $ProductId --noCommit
+    if ($LASTEXITCODE) { throw "msstore publish failed for $Name (exit $LASTEXITCODE)." }
 
-    # --- CONFIRM THESE TWO FIELD PATHS against `-Inspect` output the first time, then uncomment ---
-    #     (the exact schema — applicationPackages shape / releaseNotes location — varies per account)
-    # $sub.applicationPackages = @($packages | ForEach-Object { @{ fileName = (Split-Path $_ -Leaf); fileStatus = 'PendingUpload'; localFilePath = $_ } })
-    # $sub.listings.'en-us'.baseListing.releaseNotes = $notes[$Name]
-    throw "Fill in the two field paths above (use -Inspect to see the JSON), then remove this line. See CLAUDE.md > Store release automation."
+    # 2. Set this release's "What's new" on the draft, for every listing locale.
+    $sub = (& msstore submission get $ProductId | Out-String) | ConvertFrom-Json -Depth 60
+    foreach ($locale in @($sub.Listings.PSObject.Properties.Name)) {
+        if ($sub.Listings.$locale.BaseListing) { $sub.Listings.$locale.BaseListing.ReleaseNotes = $notes[$Name] }
+    }
+    & msstore submission update $ProductId ($sub | ConvertTo-Json -Depth 60 -Compress)
+    if ($LASTEXITCODE) { throw "msstore submission update failed for $Name (exit $LASTEXITCODE)." }
 
-    $updated = $sub | ConvertTo-Json -Depth 50
-    & msstore submission update $ProductId $updated
-    if ($NoCommit) { Write-Host '  draft updated (not published).' -ForegroundColor Yellow; return }
+    # 3. Commit + poll (unless leaving a Draft for a manual portal review).
+    if ($NoCommit) { Write-Host '  draft updated (packages + notes); NOT published - review in Partner Center.' -ForegroundColor Yellow; return }
     & msstore submission publish $ProductId
     & msstore submission poll $ProductId
 }


### PR DESCRIPTION
Adds `publish-store.ps1` to script the Microsoft Store submissions for both editions via the [Microsoft Store Developer CLI](https://learn.microsoft.com/windows/apps/publish/msstore-dev-cli/overview) (`msstore`), instead of the Partner Center portal UI — the tedious part.

## What it does
After `build-all.ps1 -Sign` produces `artifacts\store\*.msix`, for each edition it runs `msstore submission get` → patch packages + this release's "What's new" → `submission update` → `publish` → `poll`.

Flags: `-InstallTooling` (winget-installs the .NET 9 runtime + the `msstore` CLI — it's a separate install, not shipped with Windows/VS), `-Inspect` (dump the submission JSON), `-NoCommit` (leave a Draft for a portal check), `-Edition classic|modern|both`.

## Docs
- **CLAUDE.md** → new *Store release automation* section (product IDs `9NF73PSPK332` / `9NBQWCDXGF9R`, tooling install, Partner Center Azure AD auth via `msstore reconfigure`, the per-release flow).
- **README** → a pointer from the release-artifacts section.

## One open item
The exact submission-JSON field paths (`applicationPackages` shape / `releaseNotes` location) vary per account, so the script has **two clearly-marked lines** to fill in after a first `-Inspect` run. Verified: the script parses cleanly; the `msstore` calls can't be exercised here without Partner Center credentials.


---

## API stability re-check (2026-07-13, release 1.5.0 prep)

Re-validated ahead of the 1.5.0/1.2.0 release:

- **Submission API looks healthy now**: `manage.devcenter.microsoft.com/v1.0` answers unauthenticated probes with a fast, consistent `401` (~250 ms, 6/6 attempts, no 5xx) — none of the transient flakiness that prompted the retry wrapper. The AAD token endpoint is healthy too. The retry logic stays as cheap insurance.
- **StoreBroker 1.21.2** (installed) is still the PSGallery latest; the script parses clean.
- **Refreshed the per-release "What's new" copy** in the script from the stale 1.4.0 text to the 1.5.0 (classic) / 1.2.0 (modern) notes — CLI/`hfe`, Jump List, Merge, hotkey, numeric IP sort, ping indicator.

Still pending for a live run (needs the Partner Center Azure AD **client secret**, which only you can supply): `.\publish-store.ps1 -Inspect` to sanity-check the submission JSON, then `.\build-all.ps1 -Sign; .\publish-store.ps1 -NoCommit` and review the Drafts in Partner Center before committing. The environment variables it reads are `STOREBROKER_TENANTID` / `STOREBROKER_CLIENTID` / `STOREBROKER_CLIENTSECRET`.
