### PR TITLE
Classic: fuse RestoreCurrentCell anchor re-find into the selection-restore pass (#77)

### DIFF
--- a/HostsFileEditor.WinForm/Controls/HostsEntryDataGridView.cs
+++ b/HostsFileEditor.WinForm/Controls/HostsEntryDataGridView.cs
@@ -112,50 +112,125 @@ internal sealed class HostsEntryDataGridView : DataGridView
             return result;
         }
 
-        set
+        // Restoring a selection without re-anchoring the current cell is the no-anchor case of
+        // RestoreSelection; delegate so the huge-selection cap and the membership scan live in one place.
+        set => RestoreSelection(value, anchorEntry: null, anchorColumnIndex: -1);
+    }
+
+    /// <summary>
+    /// Restores <paramref name="entries"/> as the selection and, when an anchor is supplied,
+    /// re-establishes the current-cell anchor on the row now holding <paramref name="anchorEntry"/> —
+    /// in a SINGLE pass over the bound view. This fuses what used to be two O(view.Count) scans per
+    /// sort/move (a separate anchor re-find, then the selection setter to reselect) into one walk of
+    /// ~400K rows instead of two.
+    /// <para>
+    /// Selection membership uses our own reference-comparer set — like Core's Remove — so a
+    /// caller-supplied set with a value-based comparer can't match the wrong duplicate row. Above
+    /// <see cref="MaxSelectionRestoreCount"/> nothing is restored and the current cell is nulled: with
+    /// the selection gone, the command handlers fall through to their <see cref="CurrentHostEntry"/>
+    /// fallback, so a survived current row would make the user's next repeat gesture (e.g. Alt+Up
+    /// after moving a &gt;20K block) silently act on ONE row — tearing it out of the block they
+    /// believe is still selected. See the constant's remarks for why full restores are O(k^2).
+    /// </para>
+    /// </summary>
+    public void RestoreSelection(IEnumerable<HostsEntry> entries, HostsEntry? anchorEntry, int anchorColumnIndex)
+    {
+        // Count before building the membership set (a >20K restore is dropped, so the set — up to
+        // ~8MB at 400K — would be allocated only to read its Count). Callers pass a List, so O(1).
+        var requested = entries as ICollection<HostsEntry> ?? [.. entries];
+
+        if (requested.Count > MaxSelectionRestoreCount)
         {
-            // Restore a selection cheaply on a huge grid: clear once, then select ONLY the matched
-            // rows by their view index (view order == grid row order; only matched rows get realized
-            // via Rows[index]). Membership uses our own reference-comparer set — like Core's Remove —
-            // so a caller-supplied set with a value-based comparer can't match the wrong duplicate
-            // row. Restores beyond MaxSelectionRestoreCount restore nothing at all (see below and
-            // the constant's remarks for why full restores are O(k^2) inside the framework).
+            // Restore NOTHING above the cap (an honest empty selection) and null the current cell.
             ClearSelection();
+            CurrentCell = null;
+            return;
+        }
 
-            // Count before building the membership set (a >20K restore is dropped, so the set — up
-            // to ~8MB at 400K — would be allocated only to read its Count). Callers pass a List, so
-            // this is O(1).
-            var requested = value as ICollection<HostsEntry> ?? [.. value];
-            if (requested.Count == 0)
+        var wantAnchor = anchorEntry is not null && anchorColumnIndex >= 0;
+
+        if (!wantAnchor)
+        {
+            // No anchor to re-establish: clear once, then select ONLY the matched rows by their view
+            // index (view order == grid row order; only matched rows get realized via Rows[index]).
+            ClearSelection();
+            if (requested.Count == 0 || BoundView() is not { } plainViews)
             {
                 return;
             }
 
-            if (requested.Count > MaxSelectionRestoreCount)
+            var plainSelected = new HashSet<HostsEntry>(requested);
+            var plainCount = Math.Min(plainViews.Count, RowCount);
+            for (var index = 0; index < plainCount; index++)
             {
-                // Restore NOTHING above the cap (an honest empty selection), and null the current
-                // cell too: with the selection gone, the command handlers fall through to their
-                // CurrentHostEntry fallback, so a survived current row would make the user's next
-                // repeat gesture (e.g. Alt+Up after moving a >20K block) silently act on ONE row —
-                // tearing it out of the block they believe is still selected. The earlier behavior
-                // of selecting just the first matched row caused exactly that corruption.
-                CurrentCell = null;
-                return;
-            }
-
-            if (BoundView() is not { } views)
-            {
-                return;
-            }
-
-            var selected = new HashSet<HostsEntry>(requested);
-            var count = Math.Min(views.Count, RowCount);
-            for (var index = 0; index < count; index++)
-            {
-                if (views[index] is { Object: { } entry } && selected.Contains(entry))
+                if (plainViews[index] is { Object: { } entry } && plainSelected.Contains(entry))
                 {
                     Rows[index].Selected = true;
                 }
+            }
+
+            return;
+        }
+
+        if (BoundView() is not { } views)
+        {
+            ClearSelection();
+            return;
+        }
+
+        // One pass: locate the anchor row and collect the rows to reselect. The anchor's row index is
+        // captured (not acted on) so the current cell can be set AFTER the scan but BEFORE reselecting
+        // — setting CurrentCell resets the selection in the grid's RowHeaderSelect mode, so it must
+        // precede the Rows[i].Selected calls that layer the selection back on. That set-then-clear-
+        // then-reselect ordering reproduces the old RestoreCurrentCell-then-setter sequence exactly
+        // (the incidental single-row selection from setting CurrentCell is dropped by ClearSelection,
+        // so a non-selected anchor is not left selected).
+        var selected = requested.Count == 0 ? null : new HashSet<HostsEntry>(requested);
+        var count = Math.Min(views.Count, RowCount);
+        List<int>? toSelect = null;
+        var anchorRowIndex = -1;
+        for (var index = 0; index < count; index++)
+        {
+            if (views[index] is not { Object: { } entry })
+            {
+                continue;
+            }
+
+            if (anchorRowIndex < 0 && ReferenceEquals(entry, anchorEntry))
+            {
+                anchorRowIndex = index;
+            }
+
+            if (selected is not null && selected.Contains(entry))
+            {
+                (toSelect ??= []).Add(index);
+            }
+        }
+
+        if (anchorRowIndex >= 0)
+        {
+            var cell = Rows[anchorRowIndex].Cells[anchorColumnIndex];
+            if (cell.Visible)
+            {
+                try
+                {
+                    CurrentCell = cell;
+                }
+                catch (InvalidOperationException)
+                {
+                    // The framework can refuse the assignment (e.g. mid-validation); leaving the
+                    // anchor unset matches the pre-restore post-sort state, so it is not a regression.
+                }
+            }
+        }
+
+        ClearSelection();
+
+        if (toSelect is not null)
+        {
+            foreach (var index in toSelect)
+            {
+                Rows[index].Selected = true;
             }
         }
     }
@@ -373,15 +448,9 @@ internal sealed class HostsEntryDataGridView : DataGridView
         _sortColumn = column;
         _sortDirection = direction;
 
-        // For a huge selection the restore below drops it and nulls CurrentCell (its
-        // >MaxSelectionRestoreCount branch), so the O(view.Count) anchor re-find + scroll would be
-        // wasted — skip it there.
-        if (restore.Count <= MaxSelectionRestoreCount)
-        {
-            RestoreCurrentCell(anchorEntry, anchorColumn);
-        }
-
-        SelectedHostEntries = restore;
+        // Re-anchor the current cell and restore the selection in one pass over the reordered view
+        // (a huge selection drops both, so the anchor re-find isn't wasted on it).
+        RestoreSelection(restore, anchorEntry, anchorColumn);
         OnSorted(EventArgs.Empty);
     }
 
@@ -404,50 +473,6 @@ internal sealed class HostsEntryDataGridView : DataGridView
         {
             // The framework can refuse to leave the current cell mid-validation; the edit is already
             // committed by EndEdit, so proceed without finalizing the placeholder rather than aborting.
-        }
-    }
-
-    /// <summary>
-    /// Re-establishes the current-cell anchor on the row now holding <paramref name="anchorEntry"/>
-    /// after a Reset reordered the view. The framework keeps <see cref="DataGridView.CurrentCell"/> at
-    /// a fixed row INDEX across a Reset, so after a sort or a Move that index holds a different entry and
-    /// <see cref="CurrentHostEntry"/> drifts — the Insert Above/Below and Move Up/Down handlers that key
-    /// off it would then act on (or no-op against) the wrong entry. Used by the sort (which also nulls
-    /// CurrentCell via <see cref="FinalizePendingNewRow"/> to fire the new-row commit) and by Move.
-    /// Called BEFORE the selection is restored, so setting the anchor can't collapse a multi-row
-    /// selection, and only for selections within the restore cap — a huge selection drops both the
-    /// selection and the anchor by design, so the caller skips this scan there.
-    /// </summary>
-    internal void RestoreCurrentCell(HostsEntry? anchorEntry, int anchorColumnIndex)
-    {
-        if (anchorEntry is null || anchorColumnIndex < 0 || BoundView() is not { } view)
-        {
-            return;
-        }
-
-        var count = Math.Min(view.Count, RowCount);
-        for (var index = 0; index < count; index++)
-        {
-            if (view[index] is not { Object: { } entry } || !ReferenceEquals(entry, anchorEntry))
-            {
-                continue;
-            }
-
-            var cell = Rows[index].Cells[anchorColumnIndex];
-            if (cell.Visible)
-            {
-                try
-                {
-                    CurrentCell = cell;
-                }
-                catch (InvalidOperationException)
-                {
-                    // The framework can refuse the assignment (e.g. mid-validation); leaving the
-                    // anchor unset matches the pre-restore post-sort state, so it is not a regression.
-                }
-            }
-
-            return;
         }
     }
 
@@ -485,12 +510,8 @@ internal sealed class HostsEntryDataGridView : DataGridView
         _sortColumn = null;
         _sortDirection = SortOrder.None;
 
-        if (restore.Count <= MaxSelectionRestoreCount)
-        {
-            RestoreCurrentCell(anchorEntry, anchorColumn);
-        }
-
-        SelectedHostEntries = restore;
+        // Re-anchor and restore selection in one pass over the un-sorted view (see ApplyColumnSort).
+        RestoreSelection(restore, anchorEntry, anchorColumn);
         OnSorted(EventArgs.Empty);
     }
 

--- a/HostsFileEditor.WinForm/MainForm.cs
+++ b/HostsFileEditor.WinForm/MainForm.cs
@@ -927,15 +927,9 @@ internal sealed partial class MainForm : Form
                 dataGridViewHostsEntries.ClearSelection();
                 HostsFile.Instance.Entries.MoveAfter(selectedEntries, belowEntry);
 
-                // Skip the anchor re-find for a huge selection: the restore below drops it and nulls
-                // CurrentCell anyway (its >MaxSelectionRestoreCount branch), so the O(n) scan + scroll
-                // would be wasted — same gate the sort path uses.
-                if (selectedEntries.Count <= HostsEntryList.HugeSelectionThreshold)
-                {
-                    dataGridViewHostsEntries.RestoreCurrentCell(anchorEntry, anchorColumn);
-                }
-
-                dataGridViewHostsEntries.SelectedHostEntries = selectedEntries;
+                // Re-anchor the current cell and restore the selection in one pass over the reordered
+                // view (a huge selection drops both, so the anchor re-find isn't wasted on it).
+                dataGridViewHostsEntries.RestoreSelection(selectedEntries, anchorEntry, anchorColumn);
             }
         }
         else if (dataGridViewHostsEntries.CurrentHostEntry != null && dataGridViewHostsEntries.CurrentRow != null)
@@ -949,8 +943,7 @@ internal sealed partial class MainForm : Form
 
                 HostsFile.Instance.Entries.MoveAfter([currentEntry], belowEntry);
 
-                dataGridViewHostsEntries.RestoreCurrentCell(anchorEntry, anchorColumn);
-                dataGridViewHostsEntries.SelectedHostEntries = selectedEntries;
+                dataGridViewHostsEntries.RestoreSelection(selectedEntries, anchorEntry, anchorColumn);
             }
         }
     }
@@ -986,13 +979,8 @@ internal sealed partial class MainForm : Form
                 dataGridViewHostsEntries.ClearSelection();
                 HostsFile.Instance.Entries.MoveBefore(selectedEntries, aboveEntry);
 
-                // See OnMoveDownClick: skip the wasted anchor re-find for a huge (dropped) selection.
-                if (selectedEntries.Count <= HostsEntryList.HugeSelectionThreshold)
-                {
-                    dataGridViewHostsEntries.RestoreCurrentCell(anchorEntry, anchorColumn);
-                }
-
-                dataGridViewHostsEntries.SelectedHostEntries = selectedEntries;
+                // See OnMoveDownClick: re-anchor + restore selection in one pass (huge drops both).
+                dataGridViewHostsEntries.RestoreSelection(selectedEntries, anchorEntry, anchorColumn);
             }
         }
         else if (dataGridViewHostsEntries.CurrentHostEntry != null && dataGridViewHostsEntries.CurrentRow != null)
@@ -1006,8 +994,7 @@ internal sealed partial class MainForm : Form
 
                 HostsFile.Instance.Entries.MoveBefore([currentEntry], aboveEntry);
 
-                dataGridViewHostsEntries.RestoreCurrentCell(anchorEntry, anchorColumn);
-                dataGridViewHostsEntries.SelectedHostEntries = selectedEntries;
+                dataGridViewHostsEntries.RestoreSelection(selectedEntries, anchorEntry, anchorColumn);
             }
         }
     }


### PR DESCRIPTION
Closes #77.

## What & why

After a sort or a Move, the classic grid did **two** full O(view.Count) walks of the bound view where **one** suffices:
1. `RestoreCurrentCell` scanned the view (by `ReferenceEquals`) to re-find the anchor row and set `CurrentCell`.
2. The `SelectedHostEntries` setter then scanned the *same* view again to reselect the matched rows.

On a ~400K-row hosts file that's two passes per sort/move. This fuses them into a single pass.

## How

New `RestoreSelection(entries, anchorEntry, anchorColumnIndex)` does one walk of the view that both locates the anchor row and collects the rows to reselect, then:

- sets `CurrentCell` to the anchor cell, **then** `ClearSelection()`, **then** `Rows[i].Selected = true` for the collected rows.

That order reproduces the **exact grid-mutation sequence** the old `RestoreCurrentCell`-then-setter path produced (`set CurrentCell → ClearSelection → Selected=true` in ascending index order) — the only thing that changed is the *side-effect-free* view reads went from two passes to one. The subtle ordering constraint is preserved: setting `CurrentCell` resets the multi-row selection in the grid's `RowHeaderSelect` mode, so it must precede the row-selection calls; and because `ClearSelection()` runs *after* it, the incidental single-row selection that setting `CurrentCell` creates is dropped, so an anchor that isn't part of the selection isn't left selected (identical to before).

The huge-selection cap (drop both selection and anchor, null `CurrentCell`) now lives **inside** `RestoreSelection`, so callers no longer hand-gate the anchor re-find with `if (count <= HugeSelectionThreshold)`.

### Call sites rewired
- **Deleted `RestoreCurrentCell`** — fully subsumed.
- `SelectedHostEntries` **setter** now delegates to `RestoreSelection(value, null, -1)` (the no-anchor case keeps the original inline, allocation-free select).
- Control: `ApplyColumnSort`, `ClearColumnSort`.
- MainForm: both `OnMoveUpClick` and both `OnMoveDownClick` branches (multi-row + single-row).

## Why it's behaviorally safe

The grid mutations (`CurrentCell =`, `ClearSelection()`, `Rows[i].Selected = true`) happen in the same order and on the same rows as before; the fusion only removes a redundant read pass. So correctness doesn't depend on my reading of the framework's exact selection semantics — whatever it did before, it does now.

## Decisions made

- **Fused MainForm's Move handlers too**, not just the control's sort paths the issue names. The identical two-scan idiom lived in all six sites; leaving four of them on the old pattern (and keeping `RestoreCurrentCell` alive just for them) would have defeated the point. All six now share the one method.
- **Skipped the optional `TryGetRowIndex` helper** the issue floated — merging the setter and the anchor re-find already collapses the "third copy" of the `Math.Min(view.Count, RowCount)` + `ObjectView.Object` idiom into one place, so a shared helper would add indirection without removing a duplicate.
- The anchor path collects matched row indices into a small `List<int>` (bounded by the 20K restore cap) so `CurrentCell` can be set before reselecting; the no-anchor path stays allocation-free.

## Verification / open questions

- Builds clean (Debug + Release, warnings-as-errors) and `dotnet format` is clean.
- ⚠️ **The classic project has no automated UI tests**, so this needs a manual smoke test: header-click sort (asc → desc → clear) and Move Up/Down with (a) a single row, (b) a multi-row selection, (c) a >20K selection — confirming the current cell re-anchors to the same entry and the selection is preserved by identity across the reorder, and that a following Insert Above/Below acts on the right entry (#78). Handing off a build for that rather than driving the GUI myself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)