### PR TITLE
Command line for both editions: switch presets, enable/disable, import/merge (#2)

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -199,7 +199,7 @@
           Condition="Exists('$(MSBuildProjectDirectory)\AppxManifest.xml')"
           DependsOnTargets="_ResolvePackagingTools;_StampSigningConfig"
           AfterTargets="Publish"
-          Inputs="@(ResolvedFileToPublish);$(ProjectDir)$(PublishDir)Elevate\HostsFileEditor.Elevate.exe;$(_PackagedOutputStampDir)$(ProjectName).signing.stamp"
+          Inputs="@(ResolvedFileToPublish);$(ProjectDir)$(PublishDir)Elevate\HostsFileEditor.Elevate.exe;$(ProjectDir)$(PublishDir)hfe.exe;$(_PackagedOutputStampDir)$(ProjectName).signing.stamp"
           Outputs="$(ProjectDir)$(PublishDir)$(AssemblyName).msix">
     <PropertyGroup>
       <_EffectivePublishDir>$(ProjectDir)$(PublishDir)</_EffectivePublishDir>
@@ -275,6 +275,8 @@
     <ItemGroup>
       <_FilesToSign Include="$(_EffectivePublishDir)$(AssemblyName).exe" Condition="Exists('$(_EffectivePublishDir)$(AssemblyName).exe')" />
       <_FilesToSign Include="$(_EffectivePublishDir)Elevate\HostsFileEditor.Elevate.exe" Condition="Exists('$(_EffectivePublishDir)Elevate\HostsFileEditor.Elevate.exe')" />
+      <!-- The console launcher (issue #2), bundled into the publish root by PublishCliLauncher. -->
+      <_FilesToSign Include="$(_EffectivePublishDir)hfe.exe" Condition="Exists('$(_EffectivePublishDir)hfe.exe')" />
     </ItemGroup>
     <Exec Condition="'$(EnableSigning)'=='true' and '$(_SignArgs)' != '' and '@(_FilesToSign)' != ''"
           Command="&quot;$(SignToolExe)&quot; sign $(_SignArgs) @(_FilesToSign->'&quot;%(FullPath)&quot;', ' ')" />

--- a/HostsFileEditor.Cli/HostsFileEditor.Cli.csproj
+++ b/HostsFileEditor.Cli/HostsFileEditor.Cli.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- Console subsystem (Exe, not WinExe): cmd/PowerShell WAIT for a console app, so `hfe -s Foo`
+         blocks in a script without needing `start /wait` — unlike the GUI HostsFileEditor.exe. -->
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <AssemblyName>hfe</AssemblyName>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <!--
+      Published self-contained + AOT so the launcher is a single native exe with no runtime
+      dependency, and therefore drops cleanly next to either app (including the self-contained WinUI
+      package). A plain Debug build stays framework-dependent for a fast inner loop — mirrors the
+      HostsFileEditor.Elevate helper.
+    -->
+    <PublishAot>true</PublishAot>
+    <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\HostsFileEditor.Core\HostsFileEditor.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/HostsFileEditor.Cli/Program.cs
+++ b/HostsFileEditor.Cli/Program.cs
@@ -1,0 +1,7 @@
+using HostsFileEditor.CommandLine;
+
+// hfe.exe — a console-subsystem launcher for the shared command line (issue #2). Because it is a
+// console app (unlike the GUI-subsystem HostsFileEditor.exe), cmd/PowerShell WAIT for it to exit, so
+// it can be used directly in a sequential script without `start /wait`. It runs the exact same Core
+// CLI as the GUI editions' headless mode, so behavior and exit codes are identical.
+return HostsCli.Run(args, Console.Out, Console.Error);

--- a/HostsFileEditor.Core.Tests/HostsArchiveListTests.cs
+++ b/HostsFileEditor.Core.Tests/HostsArchiveListTests.cs
@@ -33,6 +33,27 @@ public class HostsArchiveListTests
     }
 
     [TestMethod]
+    public void FindByName_MatchesCaseInsensitively()
+    {
+        File.WriteAllText(Path.Combine(_tempDir, "MyHosts1"), "x");
+        File.WriteAllText(Path.Combine(_tempDir, "Default"), "y");
+        HostsArchiveList.Instance.Refresh();
+
+        HostsArchiveList.Instance.FindByName("MyHosts1").ShouldNotBeNull();
+        HostsArchiveList.Instance.FindByName("myhosts1")!.FileName.ShouldBe("MyHosts1");
+        HostsArchiveList.Instance.FindByName("DEFAULT")!.FileName.ShouldBe("Default");
+    }
+
+    [TestMethod]
+    public void FindByName_ReturnsNull_WhenMissing()
+    {
+        File.WriteAllText(Path.Combine(_tempDir, "MyHosts1"), "x");
+        HostsArchiveList.Instance.Refresh();
+
+        HostsArchiveList.Instance.FindByName("nope").ShouldBeNull();
+    }
+
+    [TestMethod]
     public void Delete_RemovesFile()
     {
         var path = Path.Combine(_tempDir, "a.txt");

--- a/HostsFileEditor.Core.Tests/HostsCliTests.cs
+++ b/HostsFileEditor.Core.Tests/HostsCliTests.cs
@@ -1,0 +1,84 @@
+using HostsFileEditor.CommandLine;
+
+namespace HostsFileEditor.Core.Tests;
+
+[TestClass]
+public class HostsCliTests
+{
+    [TestMethod]
+    [DataRow("help", CliVerb.Help)]
+    [DataRow("--help", CliVerb.Help)]
+    [DataRow("-h", CliVerb.Help)]
+    [DataRow("list", CliVerb.List)]
+    [DataRow("enable", CliVerb.Enable)]
+    [DataRow("DISABLE", CliVerb.Disable)]   // case-insensitive
+    public void TryParse_NoArgVerbs(string token, CliVerb expected)
+    {
+        HostsCli.TryParse([token], out var command, out _).ShouldBeTrue();
+        command.Verb.ShouldBe(expected);
+        command.Argument.ShouldBeNull();
+    }
+
+    [TestMethod]
+    [DataRow("apply", CliVerb.Apply)]
+    [DataRow("-s", CliVerb.Apply)]          // issue #2's syntax
+    [DataRow("switch", CliVerb.Apply)]
+    [DataRow("import", CliVerb.Import)]
+    [DataRow("merge", CliVerb.Merge)]
+    public void TryParse_ArgVerbs_CaptureArgument(string token, CliVerb expected)
+    {
+        HostsCli.TryParse([token, "the-value"], out var command, out _).ShouldBeTrue();
+        command.Verb.ShouldBe(expected);
+        command.Argument.ShouldBe("the-value");
+    }
+
+    [TestMethod]
+    public void TryParse_ArgVerb_MissingArgument_Fails()
+    {
+        HostsCli.TryParse(["apply"], out _, out var error).ShouldBeFalse();
+        error.ShouldContain("preset");
+
+        HostsCli.TryParse(["merge"], out _, out var error2).ShouldBeFalse();
+        error2.ShouldContain("file");
+    }
+
+    [TestMethod]
+    public void TryParse_NoArgVerb_WithExtraArg_Fails()
+    {
+        HostsCli.TryParse(["enable", "oops"], out _, out var error).ShouldBeFalse();
+        error.ShouldContain("no arguments");
+    }
+
+    [TestMethod]
+    public void TryParse_ArgVerb_WithTooManyArgs_Fails() =>
+        HostsCli.TryParse(["import", "a", "b"], out _, out _).ShouldBeFalse();
+
+    [TestMethod]
+    public void TryParse_UnknownCommand_Fails()
+    {
+        HostsCli.TryParse(["frobnicate"], out _, out var error).ShouldBeFalse();
+        error.ShouldContain("Unknown");
+    }
+
+    [TestMethod]
+    public void Run_Help_WritesUsage_AndSucceeds()
+    {
+        using var output = new StringWriter();
+        using var error = new StringWriter();
+        var code = HostsCli.Run(["help"], output, error);
+
+        code.ShouldBe(HostsCli.ExitSuccess);
+        output.ToString().ShouldContain("apply <preset>");
+    }
+
+    [TestMethod]
+    public void Run_UnknownCommand_WritesError_AndReturnsUsageExit()
+    {
+        using var output = new StringWriter();
+        using var error = new StringWriter();
+        var code = HostsCli.Run(["frobnicate"], output, error);
+
+        code.ShouldBe(HostsCli.ExitUsage);
+        error.ToString().ShouldContain("Unknown");
+    }
+}

--- a/HostsFileEditor.Core/CommandLine/ConsoleAttach.cs
+++ b/HostsFileEditor.Core/CommandLine/ConsoleAttach.cs
@@ -1,0 +1,56 @@
+using System.Runtime.InteropServices;
+
+namespace HostsFileEditor.CommandLine;
+
+/// <summary>
+/// Lets a GUI-subsystem (WinExe) process write to the console that launched it (issue #2). Both
+/// editions are windowed apps with no console of their own, so <c>Console.Out</c> goes nowhere until
+/// we <c>AttachConsole(ATTACH_PARENT_PROCESS)</c> and re-point the standard streams at it — unless the
+/// caller already redirected stdout (a pipe or file), in which case we leave it alone so
+/// <c>HostsFileEditor.exe list &gt; out.txt</c> and <c>for /f ... ('HostsFileEditor.exe list')</c> work.
+/// </summary>
+public static partial class ConsoleAttach
+{
+    private const int AttachParentProcess = -1;
+    private const int StdOutputHandle = -11;
+    private static readonly IntPtr InvalidHandleValue = new(-1);
+
+    /// <summary>
+    /// Ensures <c>Console.Out</c>/<c>Error</c> reach the caller. If stdout is already redirected, does
+    /// nothing (the runtime already targets the redirected handle). Otherwise attaches to the launching
+    /// console and rebinds the standard streams. A no-op when there is no console at all (e.g. launched
+    /// from Explorer) — the command still runs and sets an exit code; its text just has nowhere to go.
+    /// </summary>
+    public static void AttachToParentConsole()
+    {
+        // Already have a real stdout (redirected to a pipe/file)? Leave it — Console.Out targets it.
+        var stdout = GetStdHandle(StdOutputHandle);
+        if (stdout != IntPtr.Zero && stdout != InvalidHandleValue)
+        {
+            return;
+        }
+
+        if (!AttachConsole(AttachParentProcess))
+        {
+            return;
+        }
+
+        // Rebind the standard streams to the freshly attached console (the runtime may have cached the
+        // "no console" state). AutoFlush so output isn't lost when the process exits right after.
+        // CA2000: these writers intentionally outlive this method — Console.SetOut/SetError take
+        // ownership and they live for the rest of the (short-lived CLI) process.
+#pragma warning disable CA2000
+        Console.SetOut(new StreamWriter(Console.OpenStandardOutput()) { AutoFlush = true });
+        Console.SetError(new StreamWriter(Console.OpenStandardError()) { AutoFlush = true });
+#pragma warning restore CA2000
+    }
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool AttachConsole(int dwProcessId);
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    private static partial IntPtr GetStdHandle(int nStdHandle);
+}

--- a/HostsFileEditor.Core/CommandLine/HostsCli.cs
+++ b/HostsFileEditor.Core/CommandLine/HostsCli.cs
@@ -1,0 +1,301 @@
+using HostsFileEditor.Elevation;
+
+namespace HostsFileEditor.CommandLine;
+
+/// <summary>
+/// The verbs the headless command line understands (issue #2). <c>Apply</c> switches the live hosts
+/// file to a saved preset (archive); the rest map to the corresponding <see cref="HostsFile"/> ops.
+/// </summary>
+public enum CliVerb
+{
+    Help,
+    List,
+    Apply,
+    Enable,
+    Disable,
+    Import,
+    Merge,
+}
+
+/// <summary>A parsed command: a <see cref="CliVerb"/> plus its single argument (a preset name or file path), if any.</summary>
+public sealed record CliCommand(CliVerb Verb, string? Argument);
+
+/// <summary>
+/// The shared, headless command-line surface both editions run before showing any window (issue #2).
+/// It parses argv into a <see cref="CliCommand"/> and executes it against the existing
+/// <see cref="HostsFile"/> / <see cref="HostsArchiveList"/> APIs, writing plain text to the supplied
+/// writers and returning a process exit code. Kept UI-free and dependency-free (a hand-rolled parser,
+/// not a NuGet) so it is AOT/trim-safe for the modern edition and unit-testable in isolation.
+/// </summary>
+public static class HostsCli
+{
+    public const int ExitSuccess = 0;
+    public const int ExitError = 1;   // a command ran but failed (bad preset/file, elevation declined, IO)
+    public const int ExitUsage = 2;   // the arguments could not be parsed
+
+    /// <summary>
+    /// Parses and executes; writes results/errors to the writers; returns the process exit code. The
+    /// caller decides <em>whether</em> to route to the CLI (any args that aren't a GUI-launch switch);
+    /// an unrecognized command here is a user error and returns <see cref="ExitUsage"/> rather than
+    /// silently opening a window.
+    /// </summary>
+    public static int Run(IReadOnlyList<string> args, TextWriter output, TextWriter error)
+    {
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(output);
+        ArgumentNullException.ThrowIfNull(error);
+
+        if (!TryParse(args, out var command, out var parseError))
+        {
+            error.WriteLine(parseError);
+            output.WriteLine(UsageText);
+            return ExitUsage;
+        }
+
+        try
+        {
+            return Execute(command, output, error);
+        }
+        catch (ElevationCancelledException)
+        {
+            error.WriteLine("Cancelled: administrator permission is required and was declined.");
+            return ExitError;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException or ArgumentException)
+        {
+            error.WriteLine($"Error: {ex.Message}");
+            return ExitError;
+        }
+    }
+
+    /// <summary>Parses argv into a <see cref="CliCommand"/>. Returns false with a message on bad input.</summary>
+    public static bool TryParse(IReadOnlyList<string> args, out CliCommand command, out string error)
+    {
+        ArgumentNullException.ThrowIfNull(args);
+        command = new CliCommand(CliVerb.Help, null);
+        error = string.Empty;
+
+        if (args.Count == 0 || !TryMapVerb(args[0], out var verb))
+        {
+            error = $"Unknown command '{(args.Count == 0 ? string.Empty : args[0])}'.";
+            return false;
+        }
+
+        var takesArgument = verb is CliVerb.Apply or CliVerb.Import or CliVerb.Merge;
+        if (!takesArgument)
+        {
+            if (args.Count > 1)
+            {
+                error = $"'{args[0]}' takes no arguments.";
+                return false;
+            }
+
+            command = new CliCommand(verb, null);
+            return true;
+        }
+
+        // Apply / Import / Merge each require exactly one argument (preset name or file path).
+        if (args.Count < 2 || string.IsNullOrWhiteSpace(args[1]))
+        {
+            var usageName = verb switch { CliVerb.Import => "import", CliVerb.Merge => "merge", _ => "apply" };
+            error = verb == CliVerb.Apply
+                ? "Missing preset name. Usage: apply <preset>"
+                : $"Missing file path. Usage: {usageName} <file>";
+            return false;
+        }
+
+        if (args.Count > 2)
+        {
+            error = $"Too many arguments for '{args[0]}'.";
+            return false;
+        }
+
+        command = new CliCommand(verb, args[1]);
+        return true;
+    }
+
+    private static int Execute(CliCommand command, TextWriter output, TextWriter error)
+    {
+        switch (command.Verb)
+        {
+            case CliVerb.Help:
+                output.WriteLine(UsageText);
+                return ExitSuccess;
+
+            case CliVerb.List:
+                return ListPresets(output);
+
+            case CliVerb.Apply:
+                return ApplyPreset(command.Argument!, output, error);
+
+            case CliVerb.Enable:
+                return EnableDisable(enable: true, output);
+
+            case CliVerb.Disable:
+                return EnableDisable(enable: false, output);
+
+            case CliVerb.Import:
+                return ImportFile(command.Argument!, output, error);
+
+            case CliVerb.Merge:
+                return MergeFile(command.Argument!, output, error);
+
+            default:
+                output.WriteLine(UsageText);
+                return ExitSuccess;
+        }
+    }
+
+    private static int ListPresets(TextWriter output)
+    {
+        var presets = HostsArchiveList.Instance
+            .OrderBy(a => a, HostsArchive.FileNameComparer)
+            .Select(a => a.FileName)
+            .ToList();
+
+        if (presets.Count == 0)
+        {
+            output.WriteLine("No presets found.");
+            return ExitSuccess;
+        }
+
+        output.WriteLine("Presets:");
+        foreach (var name in presets)
+        {
+            output.WriteLine($"  {name}");
+        }
+
+        return ExitSuccess;
+    }
+
+    private static int ApplyPreset(string name, TextWriter output, TextWriter error)
+    {
+        var archive = FindPreset(name);
+        if (archive is null)
+        {
+            error.WriteLine($"Preset '{name}' not found. Run 'list' to see available presets.");
+            return ExitError;
+        }
+
+        PrivilegedFileOperations.UseElevationHelper();
+        HostsFile.Instance.Import(archive.FilePath);
+        HostsFile.Instance.Save();
+        output.WriteLine($"Applied preset '{archive.FileName}' to the hosts file.");
+        return ExitSuccess;
+    }
+
+    private static int EnableDisable(bool enable, TextWriter output)
+    {
+        PrivilegedFileOperations.UseElevationHelper();
+
+        if (enable)
+        {
+            if (HostsFile.IsEnabled)
+            {
+                output.WriteLine("The hosts file is already enabled.");
+                return ExitSuccess;
+            }
+
+            HostsFile.Instance.EnableHostsFile();
+            output.WriteLine("Enabled the hosts file.");
+        }
+        else
+        {
+            if (!HostsFile.IsEnabled)
+            {
+                output.WriteLine("The hosts file is already disabled.");
+                return ExitSuccess;
+            }
+
+            HostsFile.Instance.DisableHostsFile();
+            output.WriteLine("Disabled the hosts file.");
+        }
+
+        return ExitSuccess;
+    }
+
+    private static int ImportFile(string path, TextWriter output, TextWriter error)
+    {
+        if (!File.Exists(path))
+        {
+            error.WriteLine($"File not found: {path}");
+            return ExitError;
+        }
+
+        PrivilegedFileOperations.UseElevationHelper();
+        HostsFile.Instance.Import(path);
+        HostsFile.Instance.Save();
+        output.WriteLine($"Imported '{path}' and saved the hosts file.");
+        return ExitSuccess;
+    }
+
+    private static int MergeFile(string path, TextWriter output, TextWriter error)
+    {
+        if (!File.Exists(path))
+        {
+            error.WriteLine($"File not found: {path}");
+            return ExitError;
+        }
+
+        PrivilegedFileOperations.UseElevationHelper();
+        var added = HostsFile.Instance.Merge(path);
+        HostsFile.Instance.Save();
+        output.WriteLine(added == 0
+            ? "No new entries were added - every entry in that file is already present."
+            : $"Merged {added} new {(added == 1 ? "entry" : "entries")} and saved the hosts file.");
+        return ExitSuccess;
+    }
+
+    private static HostsArchive? FindPreset(string name)
+    {
+        // Match the archive by file name, case-insensitively, with or without the exact spelling the
+        // user saved (they may or may not include an extension).
+        var presets = HostsArchiveList.Instance;
+        return presets.FirstOrDefault(a => string.Equals(a.FileName, name, StringComparison.OrdinalIgnoreCase))
+            ?? presets.FirstOrDefault(a => string.Equals(Path.GetFileNameWithoutExtension(a.FileName), name, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static bool TryMapVerb(string token, out CliVerb verb)
+    {
+        // Normalize with ToUpperInvariant (CA1308) — matched against ASCII literals, case-insensitive.
+        verb = token.ToUpperInvariant() switch
+        {
+            "HELP" or "--HELP" or "-H" or "-?" or "/?" => CliVerb.Help,
+            "LIST" or "--LIST" or "-L" => CliVerb.List,
+            "APPLY" or "SWITCH" or "-S" or "--SWITCH" => CliVerb.Apply,
+            "ENABLE" or "--ENABLE" => CliVerb.Enable,
+            "DISABLE" or "--DISABLE" => CliVerb.Disable,
+            "IMPORT" or "--IMPORT" => CliVerb.Import,
+            "MERGE" or "--MERGE" => CliVerb.Merge,
+            _ => (CliVerb)(-1),
+        };
+
+        return Enum.IsDefined(verb);
+    }
+
+    public static string UsageText =>
+        """
+        Hosts File Editor - command line
+
+        Usage:
+          HostsFileEditor.exe <command> [argument]
+
+        Commands:
+          apply <preset>    Switch the hosts file to a saved preset (archive). Alias: -s <preset>
+          enable            Enable the hosts file.
+          disable           Disable the hosts file (renames it aside).
+          import <file>     Replace the hosts file with <file>, then save.
+          merge  <file>     Merge <file> into the hosts file (skipping duplicates), then save.
+          list              List available presets.
+          help              Show this help. Aliases: --help, -h
+
+        Notes:
+          Commands that change the hosts file need administrator rights; you will get a UAC
+          prompt unless the shell is already elevated. With no command the app opens normally.
+
+        Examples:
+          HostsFileEditor.exe -s MyHosts1
+          HostsFileEditor.exe disable
+          HostsFileEditor.exe merge "C:\path\to\extra-hosts.txt"
+        """;
+}

--- a/HostsFileEditor.Core/CommandLine/HostsCli.cs
+++ b/HostsFileEditor.Core/CommandLine/HostsCli.cs
@@ -61,11 +61,23 @@ public static class HostsCli
             error.WriteLine("Cancelled: administrator permission is required and was declined.");
             return ExitError;
         }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException or ArgumentException)
+        catch (UnauthorizedAccessException)
+        {
+            // Direct write was denied and elevation wasn't available (e.g. hfe.exe run without its
+            // Elevate\ helper alongside, or elevation blocked by policy).
+            error.WriteLine("Access denied. Run this from an elevated console, or run the copy of hfe.exe installed with the app (its elevation helper must sit alongside it).");
+            return ExitError;
+        }
+        // Top-level guard for a CLI: turn ANY other failure (a failed runas launch throws Win32Exception,
+        // a corrupt hosts file, etc.) into a clean one-line message + non-zero exit, never a raw
+        // stack-trace crash. CA1031 is intentional — this is the process's last-chance handler.
+#pragma warning disable CA1031
+        catch (Exception ex)
         {
             error.WriteLine($"Error: {ex.Message}");
             return ExitError;
         }
+#pragma warning restore CA1031
     }
 
     /// <summary>Parses argv into a <see cref="CliCommand"/>. Returns false with a message on bad input.</summary>
@@ -181,7 +193,19 @@ public static class HostsCli
         HostsFile.Instance.Import(archive.FilePath);
         HostsFile.Instance.Save();
         output.WriteLine($"Applied preset '{archive.FileName}' to the hosts file.");
+        NoteIfDisabled(output);
         return ExitSuccess;
+    }
+
+    // A mutating write goes to whatever file HostsFile currently targets — which is hosts.disabled when
+    // the hosts file is disabled. Warn so "Applied/Imported/Merged ... to the hosts file" isn't read as
+    // "the live file changed"; it takes effect on the next `enable`.
+    private static void NoteIfDisabled(TextWriter output)
+    {
+        if (!HostsFile.IsEnabled)
+        {
+            output.WriteLine("Note: the hosts file is currently DISABLED, so this changed the disabled copy - run 'enable' for it to take effect.");
+        }
     }
 
     private static int EnableDisable(bool enable, TextWriter output)
@@ -226,6 +250,7 @@ public static class HostsCli
         HostsFile.Instance.Import(path);
         HostsFile.Instance.Save();
         output.WriteLine($"Imported '{path}' and saved the hosts file.");
+        NoteIfDisabled(output);
         return ExitSuccess;
     }
 
@@ -243,16 +268,19 @@ public static class HostsCli
         output.WriteLine(added == 0
             ? "No new entries were added - every entry in that file is already present."
             : $"Merged {added} new {(added == 1 ? "entry" : "entries")} and saved the hosts file.");
+        NoteIfDisabled(output);
         return ExitSuccess;
     }
 
     private static HostsArchive? FindPreset(string name)
     {
-        // Exact file-name match first (HostsArchiveList.FindByName), then a lenient match ignoring the
-        // extension so `MyHosts1` resolves `MyHosts1.txt` too.
+        // Tolerate surrounding whitespace from a quoted argument, then match by exact file name
+        // (HostsArchiveList.FindByName) and finally ignoring the extension so `MyHosts1` resolves
+        // `MyHosts1.txt` too.
+        var trimmed = name.Trim();
         var presets = HostsArchiveList.Instance;
-        return presets.FindByName(name)
-            ?? presets.FirstOrDefault(a => string.Equals(Path.GetFileNameWithoutExtension(a.FileName), name, StringComparison.OrdinalIgnoreCase));
+        return presets.FindByName(trimmed)
+            ?? presets.FirstOrDefault(a => string.Equals(Path.GetFileNameWithoutExtension(a.FileName), trimmed, StringComparison.OrdinalIgnoreCase));
     }
 
     private static bool TryMapVerb(string token, out CliVerb verb)
@@ -278,7 +306,7 @@ public static class HostsCli
         Hosts File Editor - command line
 
         Usage:
-          HostsFileEditor.exe <command> [argument]
+          hfe <command> [argument]
 
         Commands:
           apply <preset>    Switch the hosts file to a saved preset (archive). Alias: -s <preset>
@@ -292,10 +320,12 @@ public static class HostsCli
         Notes:
           Commands that change the hosts file need administrator rights; you will get a UAC
           prompt unless the shell is already elevated. With no command the app opens normally.
+          Use hfe.exe in scripts (cmd waits for it); HostsFileEditor.exe also works but, being a
+          windowed app, needs `start /wait` for sequential steps.
 
         Examples:
-          HostsFileEditor.exe -s MyHosts1
-          HostsFileEditor.exe disable
-          HostsFileEditor.exe merge "C:\path\to\extra-hosts.txt"
+          hfe -s MyHosts1
+          hfe disable
+          hfe merge "C:\path\to\extra-hosts.txt"
         """;
 }

--- a/HostsFileEditor.Core/CommandLine/HostsCli.cs
+++ b/HostsFileEditor.Core/CommandLine/HostsCli.cs
@@ -248,10 +248,10 @@ public static class HostsCli
 
     private static HostsArchive? FindPreset(string name)
     {
-        // Match the archive by file name, case-insensitively, with or without the exact spelling the
-        // user saved (they may or may not include an extension).
+        // Exact file-name match first (HostsArchiveList.FindByName), then a lenient match ignoring the
+        // extension so `MyHosts1` resolves `MyHosts1.txt` too.
         var presets = HostsArchiveList.Instance;
-        return presets.FirstOrDefault(a => string.Equals(a.FileName, name, StringComparison.OrdinalIgnoreCase))
+        return presets.FindByName(name)
             ?? presets.FirstOrDefault(a => string.Equals(Path.GetFileNameWithoutExtension(a.FileName), name, StringComparison.OrdinalIgnoreCase));
     }
 

--- a/HostsFileEditor.Core/HostsArchiveList.cs
+++ b/HostsFileEditor.Core/HostsArchiveList.cs
@@ -32,6 +32,21 @@ public class HostsArchiveList : BindingList<HostsArchive>
 
     public static HostsArchiveList Instance => _instance.Value;
 
+    /// <summary>
+    /// Finds an archive by its file name, case-insensitively (the Windows file system's own rule and
+    /// the same comparison <see cref="HostsArchive.FileNameComparer"/> uses). Returns
+    /// <see langword="null"/> when no archive matches. Used by the command-line preset switch (issue
+    /// #2) to resolve a name like <c>MyHosts1</c> to the archive to apply; matches the exact file name
+    /// the archive was saved under (archives are stored as a file named for the archive).
+    /// </summary>
+    public HostsArchive? FindByName(string name)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+
+        return this.FirstOrDefault(
+            archive => string.Equals(archive.FileName, name, StringComparison.OrdinalIgnoreCase));
+    }
+
     public void Delete(HostsArchive archive)
     {
         ArgumentNullException.ThrowIfNull(archive);

--- a/HostsFileEditor.WinForm/AppxManifest.xml
+++ b/HostsFileEditor.WinForm/AppxManifest.xml
@@ -2,8 +2,9 @@
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
          xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
          xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+         xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5"
          xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
-         IgnorableNamespaces="uap mp rescap">
+         IgnorableNamespaces="uap uap5 mp rescap">
   <Identity Name="11033ScottLerch.HostsFileEditorclassic"
             Publisher="CN=427E0D6A-DF11-4676-8850-592258173525"
             Version="1.3.0.0"
@@ -34,6 +35,27 @@
         Square44x44Logo="Assets\Square44x44Logo.png">
         <uap:SplashScreen Image="Assets\Square150x150Logo.png"/>
       </uap:VisualElements>
+    </Application>
+    <!-- Console launcher (issue #2): a hidden app entry whose appExecutionAlias puts `hfe` on PATH so
+         scripts can run `hfe -s Preset` etc. AppListEntry="none" keeps it off the Start menu. hfe.exe
+         is console-subsystem, so cmd/PowerShell wait for it. -->
+    <Application Id="Cli"
+                 Executable="hfe.exe"
+                 EntryPoint="Windows.FullTrustApplication">
+      <uap:VisualElements
+        DisplayName="Hosts File Editor CLI"
+        Description="Hosts File Editor command line"
+        AppListEntry="none"
+        BackgroundColor="transparent"
+        Square150x150Logo="Assets\Square150x150Logo.png"
+        Square44x44Logo="Assets\Square44x44Logo.png"/>
+      <Extensions>
+        <uap5:Extension Category="windows.appExecutionAlias" Executable="hfe.exe" EntryPoint="Windows.FullTrustApplication">
+          <uap5:AppExecutionAlias>
+            <uap5:ExecutionAlias Alias="hfe.exe"/>
+          </uap5:AppExecutionAlias>
+        </uap5:Extension>
+      </Extensions>
     </Application>
   </Applications>
   <Capabilities>

--- a/HostsFileEditor.WinForm/HostsFileEditor.WinForm.csproj
+++ b/HostsFileEditor.WinForm/HostsFileEditor.WinForm.csproj
@@ -106,6 +106,21 @@
     <Message Importance="high" Text="Bundled elevation helper into $(PublishDir)Elevate" />
   </Target>
 
+  <!-- Publish the console launcher (AOT, self-contained single native exe) for this app's RID and drop
+       hfe.exe into the publish root so the ZIP / MSIX package ships it (and the MSIX alias resolves). -->
+  <Target Name="PublishCliLauncher" AfterTargets="Publish" BeforeTargets="SignAndPackage">
+    <PropertyGroup>
+      <_CliRid Condition="'$(_CliRid)' == ''">$(RuntimeIdentifier)</_CliRid>
+      <_CliRid Condition="'$(_CliRid)' == ''">win-x64</_CliRid>
+      <_CliStaging>$(MSBuildProjectDirectory)\obj\cli\$(Configuration)\$(_CliRid)\</_CliStaging>
+    </PropertyGroup>
+    <MSBuild Projects="$(MSBuildThisFileDirectory)..\HostsFileEditor.Cli\HostsFileEditor.Cli.csproj"
+             Targets="Publish"
+             Properties="Configuration=$(Configuration);RuntimeIdentifier=$(_CliRid);PublishDir=$(_CliStaging)" />
+    <Copy SourceFiles="$(_CliStaging)hfe.exe" DestinationFolder="$(PublishDir)" SkipUnchangedFiles="true" />
+    <Message Importance="high" Text="Bundled hfe.exe launcher into $(PublishDir)" />
+  </Target>
+
   <Target Name="CreateBuildDirectories" BeforeTargets="BeforeBuild">
     <MakeDir Directories="$(MSBuildProjectDirectory)\..\artifacts" Condition="!Exists('$(MSBuildProjectDirectory)\..\artifacts')" />
   </Target>

--- a/HostsFileEditor.WinForm/HostsFileEditor.WinForm.csproj
+++ b/HostsFileEditor.WinForm/HostsFileEditor.WinForm.csproj
@@ -106,6 +106,28 @@
     <Message Importance="high" Text="Bundled elevation helper into $(PublishDir)Elevate" />
   </Target>
 
+  <!-- Strip the WPF native libraries the .NET Windows Desktop runtime bundles. This is a WinForms app
+       (UseWindowsForms, never UseWPF) and never initializes WPF, so wpfgfx / PresentationNative / PenImc
+       / D3DCompiler and their vcruntime dependency are ~9 MB of dead weight — verified the app launches
+       and runs with all of them removed. Single-file leaves native libs loose next to the exe
+       (IncludeNativeLibrariesForSelfExtract isn't set), so delete them from the publish output before
+       the ZIP/MSIX is built. Same approach the modern app uses for its unused Windows App SDK libs. -->
+  <Target Name="_StripUnusedWpfNativeLibs" AfterTargets="Publish" BeforeTargets="SignAndPackage">
+    <ItemGroup>
+      <_UnusedWpfLib Include="$(PublishDir)wpfgfx_cor3.dll" />
+      <_UnusedWpfLib Include="$(PublishDir)PresentationNative_cor3.dll" />
+      <_UnusedWpfLib Include="$(PublishDir)PenImc_cor3.dll" />
+      <_UnusedWpfLib Include="$(PublishDir)D3DCompiler_47_cor3.dll" />
+      <_UnusedWpfLib Include="$(PublishDir)vcruntime140_cor3.dll" />
+    </ItemGroup>
+    <!-- Warn (don't fail) if one is missing: a future runtime bump that renames/relocates one would
+         otherwise silently stop stripping and the ~9 MB creeps back with no signal. -->
+    <Warning Condition="!Exists('%(_UnusedWpfLib.Identity)')"
+             Text="Expected unused WPF native lib not found (runtime layout may have changed): %(_UnusedWpfLib.Identity)" />
+    <Delete Files="@(_UnusedWpfLib)" />
+    <Message Importance="high" Text="Stripped unused WPF native libraries from the classic publish output." />
+  </Target>
+
   <!-- Publish the console launcher (AOT, self-contained single native exe) for this app's RID and drop
        hfe.exe into the publish root so the ZIP / MSIX package ships it (and the MSIX alias resolves). -->
   <Target Name="PublishCliLauncher" AfterTargets="Publish" BeforeTargets="SignAndPackage">

--- a/HostsFileEditor.WinForm/Program.cs
+++ b/HostsFileEditor.WinForm/Program.cs
@@ -1,3 +1,4 @@
+using HostsFileEditor.CommandLine;
 using HostsFileEditor.Properties;
 
 namespace HostsFileEditor;
@@ -16,8 +17,19 @@ internal static class Program
     /// The main entry point for the application.
     /// </summary>
     [STAThread]
-    private static void Main()
+    private static int Main(string[] args)
     {
+        // Headless command line (issue #2): any argument that isn't the Jump List's GUI-launch switch
+        // (--open-archive) is treated as a command — run it against the launching console and exit with
+        // a status code, never showing a window (an unknown command reports an error rather than opening
+        // the GUI). No args, or --open-archive, falls through to the normal windowed startup.
+        if (args.Length > 0 &&
+            !string.Equals(args[0], TaskbarJumpList.OpenArchiveSwitch, StringComparison.OrdinalIgnoreCase))
+        {
+            ConsoleAttach.AttachToParentConsole();
+            return HostsCli.Run(args, Console.Out, Console.Error);
+        }
+
         // Ensure only one copy of the application is running at a time
         using var program = ProgramSingleInstance.Start();
         if (program.IsOnlyInstance)
@@ -47,6 +59,8 @@ internal static class Program
 
             ProgramSingleInstance.ShowFirstInstance();
         }
+
+        return 0;
     }
 
     /// <summary>

--- a/HostsFileEditor.WinUI/AppxManifest.xml
+++ b/HostsFileEditor.WinUI/AppxManifest.xml
@@ -2,8 +2,9 @@
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
          xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
          xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+         xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5"
          xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
-         IgnorableNamespaces="uap mp rescap">
+         IgnorableNamespaces="uap uap5 mp rescap">
   <Identity Name="11033ScottLerch.HostsFileEditormodern"
             Publisher="CN=427E0D6A-DF11-4676-8850-592258173525"
             Version="1.0.0.0"
@@ -35,6 +36,27 @@
         Square44x44Logo="Assets\Square44x44Logo.png">
         <uap:SplashScreen Image="Assets\Square150x150Logo.png"/>
       </uap:VisualElements>
+    </Application>
+    <!-- Console launcher (issue #2): a hidden app entry whose appExecutionAlias puts `hfe` on PATH so
+         scripts can run `hfe -s Preset` etc. AppListEntry="none" keeps it off the Start menu. hfe.exe
+         is console-subsystem, so cmd/PowerShell wait for it. -->
+    <Application Id="Cli"
+                 Executable="hfe.exe"
+                 EntryPoint="Windows.FullTrustApplication">
+      <uap:VisualElements
+        DisplayName="Hosts File Editor CLI"
+        Description="Hosts File Editor command line"
+        AppListEntry="none"
+        BackgroundColor="transparent"
+        Square150x150Logo="Assets\Square150x150Logo.png"
+        Square44x44Logo="Assets\Square44x44Logo.png"/>
+      <Extensions>
+        <uap5:Extension Category="windows.appExecutionAlias" Executable="hfe.exe" EntryPoint="Windows.FullTrustApplication">
+          <uap5:AppExecutionAlias>
+            <uap5:ExecutionAlias Alias="hfe.exe"/>
+          </uap5:AppExecutionAlias>
+        </uap5:Extension>
+      </Extensions>
     </Application>
   </Applications>
   <Capabilities>

--- a/HostsFileEditor.WinUI/HostsFileEditor.WinUI.csproj
+++ b/HostsFileEditor.WinUI/HostsFileEditor.WinUI.csproj
@@ -115,6 +115,21 @@
     <Content Include="HostsFileEditor.ico" />
   </ItemGroup>
 
+  <!-- Publish the console launcher (AOT, self-contained single native exe) for this app's RID and drop
+       hfe.exe into the publish root so the MSIX package ships it (and the appExecutionAlias resolves). -->
+  <Target Name="PublishCliLauncher" AfterTargets="Publish" BeforeTargets="SignAndPackage">
+    <PropertyGroup>
+      <_CliRid Condition="'$(_CliRid)' == ''">$(RuntimeIdentifier)</_CliRid>
+      <_CliRid Condition="'$(_CliRid)' == ''">win-x64</_CliRid>
+      <_CliStaging>$(MSBuildProjectDirectory)\obj\cli\$(Configuration)\$(_CliRid)\</_CliStaging>
+    </PropertyGroup>
+    <MSBuild Projects="$(MSBuildThisFileDirectory)..\HostsFileEditor.Cli\HostsFileEditor.Cli.csproj"
+             Targets="Publish"
+             Properties="Configuration=$(Configuration);RuntimeIdentifier=$(_CliRid);PublishDir=$(_CliStaging)" />
+    <Copy SourceFiles="$(_CliStaging)hfe.exe" DestinationFolder="$(PublishDir)" SkipUnchangedFiles="true" />
+    <Message Importance="high" Text="Bundled hfe.exe launcher into $(PublishDir)" />
+  </Target>
+
   <!-- Strip ~43 MB of Windows App SDK components this app never uses. The self-contained WinUI
        runtime bundles the Windows ML / Copilot stack (onnxruntime + DirectML) and the Widgets
        APIs; a hosts-file editor references none of it. There is no supported property to exclude

--- a/HostsFileEditor.WinUI/HostsFileEditor.WinUI.csproj
+++ b/HostsFileEditor.WinUI/HostsFileEditor.WinUI.csproj
@@ -38,6 +38,9 @@
          list minimal. -->
     <NoWarn>$(NoWarn);IDE0079;IDE0060;CA1822;IL2081;CA5392</NoWarn>
     <ApplicationIcon>Assets\HostsFileEditor.ico</ApplicationIcon>
+    <!-- Provide our own Program.Main (Program.cs) so a headless command-line invocation (issue #2) can
+         run before the WinUI stack boots. Disables the auto-generated XAML entry point. -->
+    <DefineConstants>$(DefineConstants);DISABLE_XAML_GENERATED_MAIN</DefineConstants>
     <PackagingFlavor>modern</PackagingFlavor>
     <OutputPackagingDir>$(MSBuildProjectDirectory)\..\artifacts\modern\</OutputPackagingDir>
     <CreatePublishZip>false</CreatePublishZip>

--- a/HostsFileEditor.WinUI/Program.cs
+++ b/HostsFileEditor.WinUI/Program.cs
@@ -1,0 +1,38 @@
+using HostsFileEditor.CommandLine;
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml;
+
+namespace HostsFileEditor;
+
+/// <summary>
+/// The modern edition's entry point (replaces the auto-generated XAML Main via
+/// <c>DISABLE_XAML_GENERATED_MAIN</c>) so a headless command-line invocation (issue #2) can run and
+/// exit before the WinUI stack is booted. With no command — or a Jump List preset launch — it starts
+/// the app exactly as the generated Main did.
+/// </summary>
+public static class Program
+{
+    [STAThread]
+    private static int Main(string[] args)
+    {
+        // Any argument that isn't a Jump List preset launch (open-archive:<path>) is a command: run it
+        // against the launching console and exit without initializing WinUI (the ops are pure Core). An
+        // unknown command reports an error rather than opening a window.
+        if (args.Length > 0 && !args[0].StartsWith(TaskbarJumpList.OpenArchivePrefix, StringComparison.Ordinal))
+        {
+            ConsoleAttach.AttachToParentConsole();
+            return HostsCli.Run(args, Console.Out, Console.Error);
+        }
+
+        WinRT.ComWrappersSupport.InitializeComWrappers();
+        Application.Start(callbackParams =>
+        {
+            _ = callbackParams;
+            var context = new DispatcherQueueSynchronizationContext(DispatcherQueue.GetForCurrentThread());
+            SynchronizationContext.SetSynchronizationContext(context);
+            _ = new App();
+        });
+
+        return 0;
+    }
+}

--- a/HostsFileEditor.slnx
+++ b/HostsFileEditor.slnx
@@ -19,6 +19,7 @@
     <File Path="Readme.md" />
     <File Path="_config.yml" />
   </Folder>
+  <Project Path="HostsFileEditor.Cli/HostsFileEditor.Cli.csproj" />
   <Project Path="HostsFileEditor.Core.Tests/HostsFileEditor.Core.Tests.csproj" />
   <Project Path="HostsFileEditor.Core/HostsFileEditor.Core.csproj" />
   <Project Path="HostsFileEditor.Elevate/HostsFileEditor.Elevate.csproj" />


### PR DESCRIPTION
Closes #2.

## What & why

Adds a **headless command line** to **both editions** so a script can switch hosts-file presets (and enable/disable, import/merge) around a program run — the request in issue #2 — plus a small **console-subsystem launcher, `hfe.exe`**, so sequential scripts just work:

```bat
hfe -s MyHosts1
program.exe
hfe -s DefaultHosts
```

Launched with a command, the app runs **headless** (no window), prints to the launching console, and exits with a status code. Launched with no command it opens the GUI exactly as before.

## Commands

| Command | Effect |
|---|---|
| `apply <preset>` (alias `-s`) | Switch the hosts file to a saved preset (archive) |
| `enable` / `disable` | Toggle the whole hosts file |
| `import <file>` | Replace the hosts file with `<file>`, then save |
| `merge <file>` | Merge `<file>` into the hosts file (skipping duplicates), then save |
| `list` | List available presets |
| `help` (`--help`, `-h`) | Usage |

Exit codes: **0** success · **1** runtime error (preset/file not found, elevation declined, any I/O) · **2** usage error (unknown/malformed command). Mutating commands write the live hosts file, so they elevate on demand (a UAC prompt unless the shell is already elevated; a declined prompt → exit 1).

## How

- **Shared Core CLI** — `HostsFileEditor.Core/CommandLine/HostsCli.cs`: a dependency-free, **hand-rolled** parser + runner (no NuGet, so it's AOT/trim-safe and unit-testable) that executes against the existing `HostsFile` / `HostsArchiveList` APIs. `HostsArchiveList.FindByName` resolves a preset name. A top-level handler turns any failure into a clean one-line message + exit code (never a stack-trace crash).
- **Console output from a GUI exe** — `ConsoleAttach` uses `AttachConsole(ATTACH_PARENT_PROCESS)` so `HostsFileEditor.exe -s Foo` prints to the calling `cmd`, while **leaving redirected stdout alone** so `... list > out.txt` and `for /f ('... list')` capture still work.
- **Classic** `Program.Main` routes any arg that isn't the Jump List's `--open-archive` to the CLI; an unknown command reports an error rather than silently opening the GUI.
- **Modern** replaces the auto-generated XAML `Main` (`DISABLE_XAML_GENERATED_MAIN`) with a custom `Program.Main` that runs the CLI for any arg that isn't a preset launch (`open-archive:`), then boots WinUI exactly as before otherwise (the CLI path never initializes WinUI — the ops are pure Core).
- **`hfe.exe` launcher** — the GUI exe is GUI-subsystem, so `cmd` doesn't *wait* for it. New **`HostsFileEditor.Cli`** project (`AssemblyName=hfe`) is a **console-subsystem** exe running the same Core CLI, so `cmd`/PowerShell wait for it. It's **AOT + self-contained on publish** (a single ~3.8 MB native exe, no runtime dependency), framework-dependent for the Debug inner loop — mirroring the `Elevate` helper. Both apps' `PublishCliLauncher` target bundles `hfe.exe` into the publish root, it's added to the **Authenticode signing** list, and both AppxManifests declare a hidden app (`AppListEntry="none"`) with a `windows.appExecutionAlias` so **`hfe` is on PATH** for the packaged editions.

## Decisions

- **Hand-rolled parser, not System.CommandLine** — for a ~6-command surface the beta dependency wasn't worth the AOT/trim risk to the modern edition's warnings-as-errors build.
- **Default combo/behavior:** the CLI runs as an **independent headless process** (skips single-instance) so a scripted switch isn't blocked by an open window; if the GUI is open it won't reflect a CLI change until Refresh.
- **`apply`/`import`/`merge` operate on the current file** (whatever enabled/disabled state); when the hosts file is disabled they write the disabled copy and print a note that it takes effect on `enable`.

## Also in here

- **Classic: strip ~9 MB of unused WPF native libs** from the self-contained publish (`wpfgfx_cor3`, `PresentationNative_cor3`, `PenImc_cor3`, `D3DCompiler_47_cor3`, `vcruntime140_cor3`). A self-contained WinForms app bundles the Windows Desktop runtime, which ships WPF too; this app never uses WPF (verified it runs without them), so a post-publish strip target removes them — mirroring the modern app's WinApp SDK strip. Found while inspecting the release folder.

## Tests & verification

- Unit tests: `HostsCli` parser/runner (verbs/aliases/arity/unknown/help/usage-exit) and `HostsArchiveList.FindByName`. Full Core suite passes; all projects build warnings-clean.
- End-to-end: ran the real exe of **both editions** and the standalone `hfe.exe` — `help`, `list`, `apply` (found + not-found), `import`, `merge` (dedup + file output), `disable`, unknown/missing-file exit codes, and output capture. No-arg GUI launch still works in both.
- **Release publish of both editions** (self-contained, Release): `hfe.exe` AOT-compiles, is bundled into the ZIP + MSIX, and is Authenticode-signed alongside the app exe. A **package-signed MSIX** (self-distribution Publisher) installs and the `hfe` alias resolves on PATH — manually verified.

## Known limitation

The app is a GUI-subsystem exe, so a script calling **`HostsFileEditor.exe`** directly needs `start /wait "" HostsFileEditor.exe -s Foo`. **`hfe.exe` exists precisely so you don't have to** — prefer it in scripts. (MSIX *package* signing for local sideload needs a cert whose subject matches the manifest Publisher; the manifests keep the Store identity, so a self-distribution-signed variant is a separate step — see `docs/signing.md`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
