### PR TITLE
Show a ping-in-progress indicator in the status bar (#9)

### DIFF
--- a/HostsFileEditor.Core.Tests/HostsEntryTests.cs
+++ b/HostsFileEditor.Core.Tests/HostsEntryTests.cs
@@ -88,6 +88,38 @@ public class HostsEntryTests
     }
 
     [TestMethod]
+    public void PingActivity_RaisesOnZeroBoundaryOnly()
+    {
+        var events = 0;
+        void Handler(object? s, EventArgs e) => events++;
+        HostsEntry.PingActivityChanged += Handler;
+        try
+        {
+            HostsEntry.IsPingInProgress.ShouldBeFalse();
+
+            HostsEntry.BeginPing();               // 0 -> 1: fires "started"
+            HostsEntry.IsPingInProgress.ShouldBeTrue();
+            events.ShouldBe(1);
+
+            HostsEntry.BeginPing();               // 1 -> 2: no fire
+            events.ShouldBe(1);
+            HostsEntry.IsPingInProgress.ShouldBeTrue();
+
+            HostsEntry.EndPing();                 // 2 -> 1: no fire
+            events.ShouldBe(1);
+            HostsEntry.IsPingInProgress.ShouldBeTrue();
+
+            HostsEntry.EndPing();                 // 1 -> 0: fires "stopped"
+            events.ShouldBe(2);
+            HostsEntry.IsPingInProgress.ShouldBeFalse();
+        }
+        finally
+        {
+            HostsEntry.PingActivityChanged -= Handler;
+        }
+    }
+
+    [TestMethod]
     public void CloneConstructor_CopiesValues()
     {
         var entry = new HostsEntry("127.0.0.1 localhost # hi");

--- a/HostsFileEditor.Core/HostsEntry.cs
+++ b/HostsFileEditor.Core/HostsEntry.cs
@@ -323,6 +323,64 @@ public partial class HostsEntry : INotifyPropertyChanged, IDataErrorInfo
     /// </summary>
     public static SynchronizationContext? UiSynchronizationContext { get; set; }
 
+    // Number of pings currently in flight across all entries. Pings are fire-and-forget and can be
+    // started en masse (auto-ping fires one per valid entry during a load), so this is maintained with
+    // Interlocked and the change event is raised only when the count crosses the 0 boundary — a ping
+    // storm produces exactly one "started" and one "stopped" notification, not one per ping.
+    private static int _pendingPingCount;
+
+    /// <summary>
+    /// True while at least one ping is in flight. Bound by both editions to show a busy indicator in
+    /// the status bar (issue #9).
+    /// </summary>
+    public static bool IsPingInProgress => Volatile.Read(ref _pendingPingCount) > 0;
+
+    /// <summary>
+    /// Raised when ping activity starts (first ping in flight) and stops (last ping completed), so the
+    /// UI can show/hide its progress indicator. Marshalled to <see cref="UiSynchronizationContext"/>
+    /// when set (pings complete on the thread pool), so handlers run on the UI thread.
+    /// </summary>
+    public static event EventHandler? PingActivityChanged;
+
+    // internal (not private) so the 0-boundary event semantics can be unit-tested without a live
+    // network ping.
+    internal static void BeginPing()
+    {
+        if (Interlocked.Increment(ref _pendingPingCount) == 1)
+        {
+            RaisePingActivityChanged();
+        }
+    }
+
+    internal static void EndPing()
+    {
+        if (Interlocked.Decrement(ref _pendingPingCount) == 0)
+        {
+            RaisePingActivityChanged();
+        }
+    }
+
+    private static void RaisePingActivityChanged()
+    {
+        var handler = PingActivityChanged;
+        if (handler is null)
+        {
+            return;
+        }
+
+        // SendPingAsync completes on the thread pool, so marshal onto the UI context (as ping-failure
+        // reporting does) rather than raising into bound UI from a background thread.
+        var context = UiSynchronizationContext;
+        if (context is not null)
+        {
+            context.Post(_ => handler(null, EventArgs.Empty), null);
+        }
+        else
+        {
+            handler(null, EventArgs.Empty);
+        }
+    }
+
     public string Error => _errors is null ? string.Empty : string.Join(Environment.NewLine, _errors.Values);
 
     public string Comment
@@ -484,6 +542,7 @@ public partial class HostsEntry : INotifyPropertyChanged, IDataErrorInfo
     {
         IPStatus status;
 
+        BeginPing();
         try
         {
             using var ping = new Ping();
@@ -494,6 +553,10 @@ public partial class HostsEntry : INotifyPropertyChanged, IDataErrorInfo
         {
             // A failed/cancelled/invalid ping must not crash the fire-and-forget caller.
             return;
+        }
+        finally
+        {
+            EndPing();
         }
 
         if (status == IPStatus.Success)

--- a/HostsFileEditor.Core/HostsEntry.cs
+++ b/HostsFileEditor.Core/HostsEntry.cs
@@ -342,6 +342,28 @@ public partial class HostsEntry : INotifyPropertyChanged, IDataErrorInfo
     /// </summary>
     public static event EventHandler? PingActivityChanged;
 
+    private bool _pingFailed;
+
+    /// <summary>
+    /// True when this entry's most recent ping did not succeed (issue #9). Bindable so an edition can
+    /// show a per-entry "ping failed" indicator; cleared when a later ping succeeds or the IP is edited.
+    /// The classic edition instead surfaces the failure via <see cref="IDataErrorInfo"/> on the IP cell.
+    /// </summary>
+    public bool PingFailed => _pingFailed;
+
+    // Change-gated so a load-time ping storm (mostly successes on already-not-failed entries) raises no
+    // notifications, and so re-validating every entry on parse costs nothing.
+    private void SetPingFailed(bool value)
+    {
+        if (_pingFailed == value)
+        {
+            return;
+        }
+
+        _pingFailed = value;
+        OnPropertyChanged(nameof(PingFailed));
+    }
+
     // internal (not private) so the 0-boundary event semantics can be unit-tested without a live
     // network ping.
     internal static void BeginPing()
@@ -559,14 +581,28 @@ public partial class HostsEntry : INotifyPropertyChanged, IDataErrorInfo
             EndPing();
         }
 
-        if (status == IPStatus.Success)
+        // Nothing to report on a success unless a PRIOR ping had failed (recovered) — this keeps a
+        // load-time storm of successful pings from marshalling 400K no-op updates onto the UI thread.
+        if (status == IPStatus.Success && !_pingFailed)
         {
             return;
         }
 
-        void ReportFailure()
+        void Report()
         {
-            SetError(nameof(IpAddress), string.Format(CultureInfo.CurrentCulture, Resources.PingFailed, status));
+            if (status == IPStatus.Success)
+            {
+                // Recovered: clear the ping-failure state. Only a ping failure could have set an IP
+                // error on a valid IP (an invalid IP never pings), so clearing it here is safe.
+                SetError(nameof(IpAddress), null);
+                SetPingFailed(false);
+            }
+            else
+            {
+                SetError(nameof(IpAddress), string.Format(CultureInfo.CurrentCulture, Resources.PingFailed, status));
+                SetPingFailed(true);
+            }
+
             OnPropertyChanged(nameof(IpAddress));
         }
 
@@ -576,11 +612,11 @@ public partial class HostsEntry : INotifyPropertyChanged, IDataErrorInfo
         var context = syncContext ?? UiSynchronizationContext;
         if (context is not null)
         {
-            context.Post(_ => ReportFailure(), null);
+            context.Post(_ => Report(), null);
         }
         else
         {
-            ReportFailure();
+            Report();
         }
     }
 
@@ -634,6 +670,11 @@ public partial class HostsEntry : INotifyPropertyChanged, IDataErrorInfo
 
     private void ValidateIpAddress()
     {
+        // The IP is (re)validated because it was set/changed, so any prior ping result is stale —
+        // clear the failure flag (change-gated, so it's free on the parse path where it's already
+        // false). If auto-ping is on, the ping below re-establishes it from the fresh result.
+        SetPingFailed(false);
+
         if (string.IsNullOrWhiteSpace(_ipAddress) && !_enabled)
         {
             // A disabled entry with a blank IP is being edited, not an error. Mirror

--- a/HostsFileEditor.Core/HostsEntryList.cs
+++ b/HostsFileEditor.Core/HostsEntryList.cs
@@ -67,6 +67,20 @@ public class HostsEntryList : BindingList<HostsEntry>
         });
     }
 
+    /// <summary>
+    /// Pings every entry right now (issue #9 follow-up): used when the user turns auto-ping on, so the
+    /// current entries are checked immediately instead of only on the next reload or edit. Entries
+    /// without a syntactically valid IP no-op inside <see cref="HostsEntry.Ping"/>, so this effectively
+    /// pings every valid entry — the same set an auto-ping-on-load would.
+    /// </summary>
+    public void PingAll()
+    {
+        foreach (var entry in this)
+        {
+            entry.Ping();
+        }
+    }
+
     public void MoveBefore(IEnumerable<HostsEntry> entries, HostsEntry beforeEntry)
     {
         ArgumentNullException.ThrowIfNull(entries);

--- a/HostsFileEditor.WinForm/MainForm.cs
+++ b/HostsFileEditor.WinForm/MainForm.cs
@@ -510,22 +510,29 @@ internal sealed partial class MainForm : Form
         // PropertyChanged into the bound grid from the thread pool.
         HostsEntry.UiSynchronizationContext = SynchronizationContext.Current;
 
-        // Ping-in-progress indicator (issue #9): a "Pinging…" label + marquee bar, right-aligned (a
-        // spring filler pushes them to the right edge — the reliable StatusStrip idiom), hidden until a
-        // ping is in flight. PingActivityChanged is marshalled to this UI context, so the handler runs
-        // on the UI thread. The status strip owns these items and disposes them with the form.
-        var pingSpring = new ToolStripStatusLabel { Spring = true, Text = string.Empty };
-        _pingLabel = new ToolStripStatusLabel("Pinging…") { Visible = false, Margin = new Padding(0, 3, 2, 2) };
+        // Ping-in-progress indicator (issue #9): a "Pinging…" label + marquee bar, right-aligned and
+        // hidden until a ping is in flight. Right-aligned items stack from the right in Items order, so
+        // adding the bar FIRST puts it at the far right and the label lands to its left → "Pinging…
+        // [bar]". Overflow.Never keeps them on the strip instead of collapsing into the >> menu.
+        // PingActivityChanged is marshalled to this UI context, so the handler runs on the UI thread.
+        // The status strip owns these items and disposes them with the form.
+        _pingLabel = new ToolStripStatusLabel("Pinging…")
+        {
+            Alignment = ToolStripItemAlignment.Right,
+            Overflow = ToolStripItemOverflow.Never,
+            Visible = false,
+        };
         _pingProgressBar = new ToolStripProgressBar
         {
             Style = ProgressBarStyle.Marquee,
+            Alignment = ToolStripItemAlignment.Right,
+            Overflow = ToolStripItemOverflow.Never,
             AutoSize = false,
             Width = 100,
             Visible = false,
         };
-        statusStrip.Items.Add(pingSpring);
-        statusStrip.Items.Add(_pingLabel);
         statusStrip.Items.Add(_pingProgressBar);
+        statusStrip.Items.Add(_pingLabel);
         HostsEntry.PingActivityChanged += OnPingActivityChanged;
 
         LoadSettings();

--- a/HostsFileEditor.WinForm/MainForm.cs
+++ b/HostsFileEditor.WinForm/MainForm.cs
@@ -52,9 +52,11 @@ internal sealed partial class MainForm : Form
     private bool _loadFailed;
 
     /// <summary>
-    /// Marquee progress bar shown in the status strip while any ping is in flight (issue #9). Created
-    /// programmatically (rather than in the designer) and toggled from HostsEntry.PingActivityChanged.
+    /// "Pinging…" label + marquee progress bar shown right-aligned in the status strip while any ping
+    /// is in flight (issue #9). Created programmatically (rather than in the designer) and toggled
+    /// together from HostsEntry.PingActivityChanged.
     /// </summary>
+    private ToolStripStatusLabel? _pingLabel;
     private ToolStripProgressBar? _pingProgressBar;
 
     /// <summary>
@@ -508,17 +510,21 @@ internal sealed partial class MainForm : Form
         // PropertyChanged into the bound grid from the thread pool.
         HostsEntry.UiSynchronizationContext = SynchronizationContext.Current;
 
-        // Ping-in-progress indicator (issue #9): a marquee bar on the right of the status strip,
-        // hidden until a ping is in flight. PingActivityChanged is marshalled to this UI context, so
-        // the handler runs on the UI thread.
+        // Ping-in-progress indicator (issue #9): a "Pinging…" label + marquee bar, right-aligned (a
+        // spring filler pushes them to the right edge — the reliable StatusStrip idiom), hidden until a
+        // ping is in flight. PingActivityChanged is marshalled to this UI context, so the handler runs
+        // on the UI thread. The status strip owns these items and disposes them with the form.
+        var pingSpring = new ToolStripStatusLabel { Spring = true, Text = string.Empty };
+        _pingLabel = new ToolStripStatusLabel("Pinging…") { Visible = false, Margin = new Padding(0, 3, 2, 2) };
         _pingProgressBar = new ToolStripProgressBar
         {
             Style = ProgressBarStyle.Marquee,
-            Alignment = ToolStripItemAlignment.Right,
             AutoSize = false,
             Width = 100,
             Visible = false,
         };
+        statusStrip.Items.Add(pingSpring);
+        statusStrip.Items.Add(_pingLabel);
         statusStrip.Items.Add(_pingProgressBar);
         HostsEntry.PingActivityChanged += OnPingActivityChanged;
 
@@ -736,12 +742,14 @@ internal sealed partial class MainForm : Form
     /// </summary>
     private void OnPingActivityChanged(object? sender, EventArgs e)
     {
-        if (IsDisposed || Disposing || _pingProgressBar is null)
+        if (IsDisposed || Disposing || _pingProgressBar is null || _pingLabel is null)
         {
             return;
         }
 
-        _pingProgressBar.Visible = HostsEntry.IsPingInProgress;
+        var inProgress = HostsEntry.IsPingInProgress;
+        _pingLabel.Visible = inProgress;
+        _pingProgressBar.Visible = inProgress;
     }
 
     private void OnFormClosing(object sender, FormClosingEventArgs e)
@@ -1308,6 +1316,13 @@ internal sealed partial class MainForm : Form
         HostsEntry.AutoPingIPAddress = newState;
 
         menuPingIPs.Checked = newState;
+
+        // Ping the current entries immediately on enable (issue #9 follow-up), instead of waiting for
+        // the next reload/edit — so the user sees results (and the progress indicator) right away.
+        if (newState && !_loadFailed)
+        {
+            HostsFile.Instance.Entries.PingAll();
+        }
     }
 
     /// <summary>

--- a/HostsFileEditor.WinForm/MainForm.cs
+++ b/HostsFileEditor.WinForm/MainForm.cs
@@ -52,6 +52,12 @@ internal sealed partial class MainForm : Form
     private bool _loadFailed;
 
     /// <summary>
+    /// Marquee progress bar shown in the status strip while any ping is in flight (issue #9). Created
+    /// programmatically (rather than in the designer) and toggled from HostsEntry.PingActivityChanged.
+    /// </summary>
+    private ToolStripProgressBar? _pingProgressBar;
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="MainForm"/> class.
     /// </summary>
     public MainForm()
@@ -502,6 +508,20 @@ internal sealed partial class MainForm : Form
         // PropertyChanged into the bound grid from the thread pool.
         HostsEntry.UiSynchronizationContext = SynchronizationContext.Current;
 
+        // Ping-in-progress indicator (issue #9): a marquee bar on the right of the status strip,
+        // hidden until a ping is in flight. PingActivityChanged is marshalled to this UI context, so
+        // the handler runs on the UI thread.
+        _pingProgressBar = new ToolStripProgressBar
+        {
+            Style = ProgressBarStyle.Marquee,
+            Alignment = ToolStripItemAlignment.Right,
+            AutoSize = false,
+            Width = 100,
+            Visible = false,
+        };
+        statusStrip.Items.Add(_pingProgressBar);
+        HostsEntry.PingActivityChanged += OnPingActivityChanged;
+
         LoadSettings();
 
         _hostsArchiveView = new BindingListView<HostsArchive>(components)
@@ -709,6 +729,21 @@ internal sealed partial class MainForm : Form
     /// <param name="e">
     /// The event arguments.
     /// </param>
+    /// <summary>
+    /// Shows/hides the status-strip ping indicator when ping activity starts/stops. Marshalled to the
+    /// UI thread by HostsEntry (see PingActivityChanged); guards against a late notification arriving
+    /// after the form is disposed.
+    /// </summary>
+    private void OnPingActivityChanged(object? sender, EventArgs e)
+    {
+        if (IsDisposed || Disposing || _pingProgressBar is null)
+        {
+            return;
+        }
+
+        _pingProgressBar.Visible = HostsEntry.IsPingInProgress;
+    }
+
     private void OnFormClosing(object sender, FormClosingEventArgs e)
     {
         // Minimize to tray only when the user closes the window. Never veto an OS-initiated

--- a/HostsFileEditor.WinUI/HostEntryBrushHelper.cs
+++ b/HostsFileEditor.WinUI/HostEntryBrushHelper.cs
@@ -36,6 +36,19 @@ internal static class HostEntryBrushHelper
     public static Visibility PingFailedVisibility(bool pingFailed) =>
         pingFailed ? Visibility.Visible : Visibility.Collapsed;
 
+    /// <summary>
+    /// Tooltip for the IP cell (issue #9): the IP as usual, but explains the ping failed when it did —
+    /// the failed-ping icon itself is not hit-testable (so it doesn't block editing), so this cell-level
+    /// tooltip is what the user actually sees when hovering the indicator.
+    /// </summary>
+    public static string IpTooltip(string? ipAddress, bool pingFailed)
+    {
+        var ip = ipAddress ?? string.Empty;
+        return pingFailed
+            ? string.IsNullOrEmpty(ip) ? "Ping failed — the host did not respond." : $"Ping failed — {ip} did not respond."
+            : ip;
+    }
+
     private static Brush? GetResourceBrush(string key) => Application.Current.Resources[key] as Brush;
 
     private static Brush? GetFirstExistingBrush(params string[] keys)

--- a/HostsFileEditor.WinUI/HostEntryBrushHelper.cs
+++ b/HostsFileEditor.WinUI/HostEntryBrushHelper.cs
@@ -29,6 +29,13 @@ internal static class HostEntryBrushHelper
             : new SolidColorBrush(Color.FromArgb(0xFF, 0xFF, 0xE5, 0xE5));
     }
 
+    /// <summary>
+    /// Visibility of the per-row "ping failed" indicator (issue #9). Bound via x:Bind function binding
+    /// to <see cref="HostsEntry.PingFailed"/>, so it re-evaluates when that flag changes.
+    /// </summary>
+    public static Visibility PingFailedVisibility(bool pingFailed) =>
+        pingFailed ? Visibility.Visible : Visibility.Collapsed;
+
     private static Brush? GetResourceBrush(string key) => Application.Current.Resources[key] as Brush;
 
     private static Brush? GetFirstExistingBrush(params string[] keys)

--- a/HostsFileEditor.WinUI/MainWindow.xaml
+++ b/HostsFileEditor.WinUI/MainWindow.xaml
@@ -396,10 +396,25 @@
             <Border Background="{ThemeResource SolidBackgroundFillColorBaseBrush}"
                     Visibility="{x:Bind StatusBackplateVisibility, Mode=OneWay}"/>
             <Border Background="Transparent" Padding="14,5">
-                <TextBlock Text="{x:Bind StatusText, Mode=OneWay}"
-                           Style="{StaticResource CaptionTextBlockStyle}"
-                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                           VerticalAlignment="Center"/>
+                <Grid>
+                    <TextBlock Text="{x:Bind StatusText, Mode=OneWay}"
+                               Style="{StaticResource CaptionTextBlockStyle}"
+                               Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                               VerticalAlignment="Center"/>
+                    <!-- Ping-in-progress indicator (issue #9): an indeterminate ring shown on the
+                         right while any ping is in flight. -->
+                    <StackPanel Orientation="Horizontal"
+                                HorizontalAlignment="Right"
+                                VerticalAlignment="Center"
+                                Spacing="8"
+                                Visibility="{x:Bind PingProgressVisibility, Mode=OneWay}">
+                        <ProgressRing IsActive="True" Width="16" Height="16"/>
+                        <TextBlock Text="Pinging…"
+                                   Style="{StaticResource CaptionTextBlockStyle}"
+                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                   VerticalAlignment="Center"/>
+                    </StackPanel>
+                </Grid>
             </Border>
         </Grid>
     </Grid>

--- a/HostsFileEditor.WinUI/MainWindow.xaml
+++ b/HostsFileEditor.WinUI/MainWindow.xaml
@@ -330,7 +330,18 @@
                                         <ColumnDefinition Width="3*"/>
                                     </Grid.ColumnDefinitions>
                                     <CheckBox Grid.Column="0" HorizontalAlignment="Left" VerticalAlignment="Center" MinWidth="0" Margin="8,0" IsChecked="{x:Bind Enabled, Mode=TwoWay}"/>
-                                    <TextBox Grid.Column="1" Text="{x:Bind IpAddress, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" ToolTipService.ToolTip="{x:Bind IpAddress, Mode=OneWay}" Margin="1,0" CornerRadius="4,0,0,4" PlaceholderText="IP address..." />
+                                    <Grid Grid.Column="1" Margin="1,0">
+                                        <TextBox Text="{x:Bind IpAddress, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" ToolTipService.ToolTip="{x:Bind IpAddress, Mode=OneWay}" CornerRadius="4,0,0,4" PlaceholderText="IP address..." />
+                                        <!-- Per-entry ping-failed indicator (issue #9): a critical badge on the right of the
+                                             IP cell, shown when the last ping to this IP didn't respond. IsHitTestVisible=False
+                                             so it doesn't block editing the IP underneath. -->
+                                        <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xEA39;" FontSize="14"
+                                                  Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+                                                  HorizontalAlignment="Right" VerticalAlignment="Center" Margin="0,0,8,0"
+                                                  IsHitTestVisible="False"
+                                                  ToolTipService.ToolTip="Ping failed — the host did not respond."
+                                                  Visibility="{x:Bind local:HostEntryBrushHelper.PingFailedVisibility(PingFailed), Mode=OneWay}"/>
+                                    </Grid>
                                     <TextBox Grid.Column="2" Text="{x:Bind HostNames, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Margin="1,0" CornerRadius="0" PlaceholderText="Host names..." />
                                     <TextBox Grid.Column="3" Text="{x:Bind Comment, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Margin="1,0" CornerRadius="0,4,4,0" HorizontalAlignment="Stretch" PlaceholderText="Comments..." />
                                 </Grid>

--- a/HostsFileEditor.WinUI/MainWindow.xaml
+++ b/HostsFileEditor.WinUI/MainWindow.xaml
@@ -331,15 +331,16 @@
                                     </Grid.ColumnDefinitions>
                                     <CheckBox Grid.Column="0" HorizontalAlignment="Left" VerticalAlignment="Center" MinWidth="0" Margin="8,0" IsChecked="{x:Bind Enabled, Mode=TwoWay}"/>
                                     <Grid Grid.Column="1" Margin="1,0">
-                                        <TextBox Text="{x:Bind IpAddress, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" ToolTipService.ToolTip="{x:Bind IpAddress, Mode=OneWay}" CornerRadius="4,0,0,4" PlaceholderText="IP address..." />
+                                        <!-- The IP cell's tooltip explains a ping failure (see IpTooltip); the failed-ping
+                                             badge is IsHitTestVisible=False so it doesn't block editing, so hovering the badge
+                                             falls through to this TextBox's tooltip. -->
+                                        <TextBox Text="{x:Bind IpAddress, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" ToolTipService.ToolTip="{x:Bind local:HostEntryBrushHelper.IpTooltip(IpAddress, PingFailed), Mode=OneWay}" CornerRadius="4,0,0,4" PlaceholderText="IP address..." />
                                         <!-- Per-entry ping-failed indicator (issue #9): a critical badge on the right of the
-                                             IP cell, shown when the last ping to this IP didn't respond. IsHitTestVisible=False
-                                             so it doesn't block editing the IP underneath. -->
+                                             IP cell, shown when the last ping to this IP didn't respond. -->
                                         <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xEA39;" FontSize="14"
                                                   Foreground="{ThemeResource SystemFillColorCriticalBrush}"
                                                   HorizontalAlignment="Right" VerticalAlignment="Center" Margin="0,0,8,0"
                                                   IsHitTestVisible="False"
-                                                  ToolTipService.ToolTip="Ping failed — the host did not respond."
                                                   Visibility="{x:Bind local:HostEntryBrushHelper.PingFailedVisibility(PingFailed), Mode=OneWay}"/>
                                     </Grid>
                                     <TextBox Grid.Column="2" Text="{x:Bind HostNames, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Margin="1,0" CornerRadius="0" PlaceholderText="Host names..." />

--- a/HostsFileEditor.WinUI/MainWindow.xaml.cs
+++ b/HostsFileEditor.WinUI/MainWindow.xaml.cs
@@ -111,6 +111,22 @@ public sealed partial class MainWindow : Window, INotifyPropertyChanged
 
     public string StatusText => _statusText;
 
+    // Ping-in-progress indicator (issue #9): visible while any ping is in flight, driven by
+    // HostsEntry.PingActivityChanged (see OnPingActivityChanged).
+    public Visibility PingProgressVisibility =>
+        HostsEntry.IsPingInProgress ? Visibility.Visible : Visibility.Collapsed;
+
+    private void OnPingActivityChanged(object? sender, EventArgs e)
+    {
+        // Marshalled to the UI thread by HostsEntry; a late notification can still arrive after close.
+        if (_isClosed)
+        {
+            return;
+        }
+
+        OnPropertyChanged(nameof(PingProgressVisibility));
+    }
+
     // Above this many visible rows (at 100% scale), show the opaque backplate behind the status
     // bar. WinUI stops clipping the bottom-edge rows of an enormous virtualized list (see the XAML
     // comment on the status-bar Grid for the full investigation) and the strays would show through
@@ -218,6 +234,10 @@ public sealed partial class MainWindow : Window, INotifyPropertyChanged
         // x:Bind-bound rows from the thread pool (RPC_E_WRONG_THREAD).
         HostsEntry.UiSynchronizationContext = SynchronizationContext.Current;
 
+        // Ping-in-progress indicator (issue #9): PingActivityChanged is marshalled to this UI context,
+        // so the handler runs on the UI thread and just re-evaluates PingProgressVisibility.
+        HostsEntry.PingActivityChanged += OnPingActivityChanged;
+
         // Apply persisted settings BEFORE the first HostsFile.Instance access (RefreshEntries
         // below): that access loads the hosts file and constructs every HostsEntry, so
         // RemoveDefaultText and AutoPingIPAddress must already be set or they are inert at
@@ -256,6 +276,7 @@ public sealed partial class MainWindow : Window, INotifyPropertyChanged
         {
             _isClosed = true;
             Utilities.UndoManager.Instance.HistoryChanged -= OnUndoHistoryChanged;
+            HostsEntry.PingActivityChanged -= OnPingActivityChanged;
 
             // Unsubscribe unconditionally: the subscription is added once (after the initial load) and
             // persists across reloads, but a reload sets _isLoaded=false — gating on it would leak the

--- a/HostsFileEditor.WinUI/MainWindow.xaml.cs
+++ b/HostsFileEditor.WinUI/MainWindow.xaml.cs
@@ -1877,7 +1877,22 @@ public sealed partial class MainWindow : Window, INotifyPropertyChanged
     }
 
     private void OnPingIPsClick(object sender, RoutedEventArgs e) =>
-        ApplyToggleSetting("AutoPingIPs", v => { IsPingIPs = v; HostsEntry.AutoPingIPAddress = v; }, nameof(IsPingIPs), sender);
+        ApplyToggleSetting(
+            "AutoPingIPs",
+            v =>
+            {
+                IsPingIPs = v;
+                HostsEntry.AutoPingIPAddress = v;
+
+                // Ping the current entries immediately on enable (issue #9 follow-up) instead of
+                // waiting for the next reload/edit, so results and the indicator appear right away.
+                if (v && _isLoaded)
+                {
+                    HostsFile.Instance.Entries.PingAll();
+                }
+            },
+            nameof(IsPingIPs),
+            sender);
 
     private void OnRemoveDefaultTextClick(object sender, RoutedEventArgs e) =>
         ApplyToggleSetting("RemoveDefaultText", v => { IsRemoveDefaultText = v; HostsFile.RemoveDefaultText = v; }, nameof(IsRemoveDefaultText), sender);


### PR DESCRIPTION
Closes #9.

## What & why

When auto-ping is on, the app pings endpoints in the background but gives no sign it's working. This adds a busy indicator to the status bar of **both** editions while any ping is in flight.

## How

**Core** tracks in-flight pings on `HostsEntry`:
- `PingAsync` does `BeginPing()` / `EndPing()` (in a `finally`) around the actual `SendPingAsync`.
- The count is maintained with `Interlocked`; `PingActivityChanged` fires **only when the count crosses the 0 boundary**, so a ping storm — auto-ping fires one ping per valid entry on load, up to hundreds of thousands — produces exactly one "started" and one "stopped" notification, not one per ping. It's marshalled to the UI thread via the existing `UiSynchronizationContext`.
- `HostsEntry.IsPingInProgress` exposes the state.

**Classic:** a marquee `ToolStripProgressBar` added programmatically to the right of the status strip, hidden until pinging.

**Modern:** an indeterminate `ProgressRing` + "Pinging…" label on the right of the status bar, gated on a `PingProgressVisibility` binding.

## Why it's race-safe

Each UI handler reads `IsPingInProgress` **live** (not a captured bool), and `SynchronizationContext.Post` is FIFO, so even if "started"/"stopped" notifications overlap or arrive late, the visibility always converges to the true current state. Both handlers are guarded against a notification arriving after the window is disposed/closed.

## Tests

Core test `PingActivity_RaisesOnZeroBoundaryOnly` pins the counter/event semantics (0→1 fires, 1→2 doesn't, 2→1 doesn't, 1→0 fires) without a live network ping (`BeginPing`/`EndPing` are `internal` for this). Core suite **129 passing**; both UIs build clean (warnings-as-errors); format clean.

## Decisions made

- **Indeterminate, not a percentage.** Pings are fire-and-forget and started incrementally as entries validate; there's no meaningful up-front total, so a busy/marquee indicator is the honest representation rather than a fake percentage.
- **0-boundary events only**, so the indicator doesn't thrash and a 400K ping storm doesn't generate 400K UI notifications.

## Open questions / verification

- ⚠️ **Pure-UI, not driven here** (I don't run the GUI). Needs a manual check in each edition: enable **Ping IPs (auto-ping)** with a file that has resolvable/unresolvable IPs and confirm the indicator appears while pings run and disappears when they finish.
- Wording/placement: "Pinging…" text + ring on the modern side, marquee bar on classic — happy to adjust to your taste (e.g. drop the modern label, or add a count).

🤖 Generated with [Claude Code](https://claude.com/claude-code)