### PR TITLE
Windows taskbar Jump List of presets, both editions (#10)

### DIFF
--- a/HostsFileEditor.WinForm/HostsFileEditor.WinForm.csproj
+++ b/HostsFileEditor.WinForm/HostsFileEditor.WinForm.csproj
@@ -56,6 +56,9 @@
   <ItemGroup>
     <PackageReference Include="7ZipCLI" Version="9.20.0" GeneratePathProperty="true" />
     <PackageReference Include="Equin.ApplicationFramework.BindingListView" Version="1.4.5222.35545" />
+    <!-- Taskbar JumpList support (issue #10). -->
+    <PackageReference Include="WindowsAPICodePackCore" Version="8.0.15.2" />
+    <PackageReference Include="WindowsAPICodePackShell" Version="8.0.15.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\HostsFileEditor.Core\HostsFileEditor.Core.csproj" />

--- a/HostsFileEditor.WinForm/MainForm.cs
+++ b/HostsFileEditor.WinForm/MainForm.cs
@@ -91,9 +91,40 @@ internal sealed partial class MainForm : Form
             }
 
             this.ShowOrActivate();
+
+            // A second instance launched from a Jump List preset forwarded the archive path here
+            // (issue #10). Open it AFTER this message returns — BeginInvoke defers it out of the
+            // synchronous cross-process SendMessage, so the unsaved-changes MessageBox doesn't pump
+            // messages re-entrantly inside WndProc.
+            var pendingArchive = TaskbarJumpList.TakePendingOpenArchive();
+            if (pendingArchive is not null)
+            {
+                BeginInvoke(() => RequestOpenArchive(pendingArchive));
+            }
         }
 
         base.WndProc(ref message);
+    }
+
+    /// <summary>
+    /// Opens a Jump List preset (issue #10): warns if there are unsaved changes (offering to save),
+    /// then imports the archive into the editor. Shared by the fresh-launch path (OnFomLoad) and the
+    /// already-running path (WndProc forwarding).
+    /// </summary>
+    private void RequestOpenArchive(string archivePath)
+    {
+        if (string.IsNullOrEmpty(archivePath) || !File.Exists(archivePath))
+        {
+            return;
+        }
+
+        if (!ConfirmDiscardUnsavedChanges(
+                "You have unsaved changes to the hosts file. Save them before opening the preset?"))
+        {
+            return;
+        }
+
+        HostsFile.Instance.Import(archivePath);
     }
 
     /// <inheritdoc />
@@ -652,14 +683,13 @@ internal sealed partial class MainForm : Form
         TaskbarJumpList.Refresh();
         HostsArchiveList.Instance.ListChanged += (s1, e1) => TaskbarJumpList.Refresh();
 
-        // If launched from a Jump List entry (--open-archive "<path>"), import that preset into the
-        // editor now that the hosts file is loaded. (Only the fresh-launch case is handled here; a
-        // launch while the app is already running is intercepted by single-instance and would need the
-        // path forwarded through that channel — see the PR notes.)
+        // If launched fresh from a Jump List entry (--open-archive "<path>"), open that preset now
+        // that the hosts file is loaded. The already-running case is handled in WndProc (a second
+        // instance forwards the path via TaskbarJumpList). RequestOpenArchive warns on unsaved changes.
         var openArchivePath = TaskbarJumpList.TryGetOpenArchivePath(Environment.GetCommandLineArgs());
-        if (!string.IsNullOrEmpty(openArchivePath) && File.Exists(openArchivePath))
+        if (openArchivePath is not null)
         {
-            HostsFile.Instance.Import(openArchivePath);
+            RequestOpenArchive(openArchivePath);
         }
 
         // HACK: Make sure a newly added row gets committed after
@@ -818,7 +848,8 @@ internal sealed partial class MainForm : Form
     /// If there are unsaved hosts-file changes, prompts to save/discard/cancel. Returns true if
     /// the caller should proceed with exiting (saved or discarded), false to abort the exit.
     /// </summary>
-    private bool ConfirmDiscardUnsavedChanges()
+    private bool ConfirmDiscardUnsavedChanges(
+        string prompt = "You have unsaved changes to the hosts file. Save them before exiting?")
     {
         // A failed load never built any state to lose, and touching HostsFile.Instance would rethrow
         // the cached load exception (tray/File Exit reach here even after a failed load).
@@ -829,7 +860,7 @@ internal sealed partial class MainForm : Form
 
         var result = MessageBox.Show(
             this,
-            "You have unsaved changes to the hosts file. Save them before exiting?",
+            prompt,
             "Unsaved Changes",
             MessageBoxButtons.YesNoCancel,
             MessageBoxIcon.Warning);

--- a/HostsFileEditor.WinForm/MainForm.cs
+++ b/HostsFileEditor.WinForm/MainForm.cs
@@ -647,6 +647,21 @@ internal sealed partial class MainForm : Form
 
         UpdateNotifyIcon();
 
+        // Taskbar Jump List (issue #10): publish the current presets, and keep it in sync as archives
+        // are created/deleted.
+        TaskbarJumpList.Refresh();
+        HostsArchiveList.Instance.ListChanged += (s1, e1) => TaskbarJumpList.Refresh();
+
+        // If launched from a Jump List entry (--open-archive "<path>"), import that preset into the
+        // editor now that the hosts file is loaded. (Only the fresh-launch case is handled here; a
+        // launch while the app is already running is intercepted by single-instance and would need the
+        // path forwarded through that channel — see the PR notes.)
+        var openArchivePath = TaskbarJumpList.TryGetOpenArchivePath(Environment.GetCommandLineArgs());
+        if (!string.IsNullOrEmpty(openArchivePath) && File.Exists(openArchivePath))
+        {
+            HostsFile.Instance.Import(openArchivePath);
+        }
+
         // HACK: Make sure a newly added row gets committed after
         // the first cell is validated so HostsEntry validation and data
         // binding behaves correctly

--- a/HostsFileEditor.WinForm/Program.cs
+++ b/HostsFileEditor.WinForm/Program.cs
@@ -36,6 +36,15 @@ internal static class Program
         }
         else
         {
+            // A Jump List "open preset" launched this second instance (issue #10). Hand the archive
+            // path to the already-running instance (which reads it when the show-broadcast arrives),
+            // then bring it to the foreground and exit.
+            var openArchivePath = TaskbarJumpList.TryGetOpenArchivePath(Environment.GetCommandLineArgs());
+            if (openArchivePath is not null)
+            {
+                TaskbarJumpList.WritePendingOpenArchive(openArchivePath);
+            }
+
             ProgramSingleInstance.ShowFirstInstance();
         }
     }

--- a/HostsFileEditor.WinForm/TaskbarJumpList.cs
+++ b/HostsFileEditor.WinForm/TaskbarJumpList.cs
@@ -1,0 +1,80 @@
+using Microsoft.WindowsAPICodePack.Shell;
+using Microsoft.WindowsAPICodePack.Taskbar;
+
+namespace HostsFileEditor;
+
+/// <summary>
+/// Populates the Windows taskbar Jump List with the saved archives/presets (issue #10), so the user
+/// can right-click the taskbar icon and open a preset. Each entry relaunches the app with
+/// <see cref="OpenArchiveSwitch"/> "&lt;path&gt;", which the startup path imports into the editor.
+/// Best-effort: any failure (unsupported platform, COM error) is swallowed — a jump list must never
+/// crash the app.
+/// </summary>
+internal static class TaskbarJumpList
+{
+    /// <summary>Command-line switch a jump-list entry passes to open a preset in the editor.</summary>
+    public const string OpenArchiveSwitch = "--open-archive";
+
+    private const string PresetsCategory = "Presets";
+
+    public static void Refresh()
+    {
+        if (!TaskbarManager.IsPlatformSupported)
+        {
+            return;
+        }
+
+        var exePath = Environment.ProcessPath;
+        if (string.IsNullOrEmpty(exePath))
+        {
+            return;
+        }
+
+        try
+        {
+            var jumpList = JumpList.CreateJumpList();
+
+            var archives = HostsArchiveList.Instance
+                .OrderBy(a => a.FileName, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            if (archives.Count > 0)
+            {
+                var category = new JumpListCustomCategory(PresetsCategory);
+                foreach (var archive in archives)
+                {
+                    category.AddJumpListItems(new JumpListLink(exePath, archive.FileName)
+                    {
+                        Arguments = $"{OpenArchiveSwitch} \"{archive.FilePath}\"",
+                        IconReference = new IconReference(exePath, 0),
+                    });
+                }
+
+                jumpList.AddCustomCategories(category);
+            }
+
+            jumpList.Refresh();
+        }
+        catch (Exception)
+        {
+            // Jump list is a convenience; never let a shell/COM failure take down the app.
+        }
+    }
+
+    /// <summary>
+    /// Extracts the archive path from a <see cref="OpenArchiveSwitch"/> "&lt;path&gt;" argument pair,
+    /// or <see langword="null"/> if not present.
+    /// </summary>
+    public static string? TryGetOpenArchivePath(string[] args)
+    {
+        for (var i = 0; i < args.Length - 1; i++)
+        {
+            if (string.Equals(args[i], OpenArchiveSwitch, StringComparison.OrdinalIgnoreCase))
+            {
+                return args[i + 1];
+            }
+        }
+
+        return null;
+    }
+}

--- a/HostsFileEditor.WinForm/TaskbarJumpList.cs
+++ b/HostsFileEditor.WinForm/TaskbarJumpList.cs
@@ -77,4 +77,46 @@ internal static class TaskbarJumpList
 
         return null;
     }
+
+    // Single-slot hand-off file used to forward a Jump List "open preset" from a second (exiting)
+    // instance to the already-running one: the second instance can't pass the path through the
+    // payload-less single-instance broadcast (ProgramSingleInstance.ShowFirstInstance), so it drops
+    // the path here and the running instance reads it when it receives that broadcast. Best-effort.
+    private static string PendingOpenArchiveFile =>
+        Path.Combine(HostsFile.AppDataDirectory, "jumplist-pending.txt");
+
+    /// <summary>Records an archive path for the already-running instance to open (see above).</summary>
+    public static void WritePendingOpenArchive(string archivePath)
+    {
+        try
+        {
+            Directory.CreateDirectory(HostsFile.AppDataDirectory);
+            File.WriteAllText(PendingOpenArchiveFile, archivePath);
+        }
+        catch (Exception)
+        {
+            // Best-effort hand-off; a failure just means the running instance won't open the preset.
+        }
+    }
+
+    /// <summary>Reads and clears any pending open-archive path, or <see langword="null"/> if none.</summary>
+    public static string? TakePendingOpenArchive()
+    {
+        try
+        {
+            var file = PendingOpenArchiveFile;
+            if (File.Exists(file))
+            {
+                var path = File.ReadAllText(file).Trim();
+                File.Delete(file);
+                return string.IsNullOrEmpty(path) ? null : path;
+            }
+        }
+        catch (Exception)
+        {
+            // Best-effort.
+        }
+
+        return null;
+    }
 }

--- a/HostsFileEditor.WinUI/App.xaml.cs
+++ b/HostsFileEditor.WinUI/App.xaml.cs
@@ -112,9 +112,9 @@ public partial class App : Application
         {
             openArchivePath = TaskbarJumpList.TryGetOpenArchivePath(e);
         }
-        catch (Exception ex)
+        catch (Exception)
         {
-            TaskbarJumpList.Log($"OnInstanceActivated (extract) failed: {ex}");
+            // Defensive: a malformed activation must not take down the running instance.
         }
 
         _window?.DispatcherQueue.TryEnqueue(() =>
@@ -136,9 +136,9 @@ public partial class App : Application
                     mw.RequestOpenArchive(openArchivePath);
                 }
             }
-            catch (Exception ex)
+            catch (Exception)
             {
-                TaskbarJumpList.Log($"OnInstanceActivated (open) failed: {ex}");
+                // Defensive: keep the app alive if activation/foreground handling throws.
             }
         });
     }

--- a/HostsFileEditor.WinUI/App.xaml.cs
+++ b/HostsFileEditor.WinUI/App.xaml.cs
@@ -32,10 +32,13 @@ public partial class App : Application
         var keyInstance = AppInstance.FindOrRegisterForKey("HostsFileEditor.SingleInstance");
         if (!keyInstance.IsCurrent)
         {
-            // Hand this activation to the already-running instance, then exit. Wait for the
-            // redirect to complete instead of racing it with Environment.Exit (fire-and-forget).
-            keyInstance.RedirectActivationToAsync(AppInstance.GetCurrent().GetActivatedEventArgs())
-                .AsTask().GetAwaiter().GetResult();
+            // Hand this activation to the already-running instance, then exit. The redirect MUST run
+            // off the UI thread: RedirectActivationToAsync is a cross-process COM call, and blocking
+            // this STA thread with .GetResult() deadlocks it (the thread can't pump COM to complete
+            // the redirect) — so the running instance never receives the activation and appears to
+            // hang when e.g. a Jump List preset is clicked while it's open. Run it on a thread-pool
+            // (MTA) thread and wait via a semaphore, the canonical single-instance pattern.
+            RedirectActivationTo(AppInstance.GetCurrent().GetActivatedEventArgs(), keyInstance);
             Environment.Exit(0);
             return;
         }
@@ -56,6 +59,19 @@ public partial class App : Application
         }
 
         _window.Activate();
+    }
+
+    // Performs the cross-process activation redirect on a thread-pool thread and blocks this
+    // (soon-to-exit) instance until it completes — never on the UI/STA thread (see OnLaunched).
+    private static void RedirectActivationTo(AppActivationArguments args, AppInstance keyInstance)
+    {
+        using var redirected = new SemaphoreSlim(0, 1);
+        _ = Task.Run(() =>
+        {
+            keyInstance.RedirectActivationToAsync(args).AsTask().GetAwaiter().GetResult();
+            redirected.Release();
+        });
+        redirected.Wait();
     }
 
     private void OnInstanceActivated(object? sender, AppActivationArguments e) =>

--- a/HostsFileEditor.WinUI/App.xaml.cs
+++ b/HostsFileEditor.WinUI/App.xaml.cs
@@ -46,10 +46,30 @@ public partial class App : Application
         var mw = Services.GetRequiredService<MainWindow>();
 
         _window = mw;
+
+        // If launched from a taskbar Jump List preset (issue #10), hand the archive path to the window
+        // to import once it finishes loading.
+        var openArchivePath = TaskbarJumpList.TryGetOpenArchivePath(AppInstance.GetCurrent().GetActivatedEventArgs());
+        if (openArchivePath is not null)
+        {
+            mw.RequestOpenArchive(openArchivePath);
+        }
+
         _window.Activate();
     }
 
     private void OnInstanceActivated(object? sender, AppActivationArguments e) =>
-        // Raised on a background thread; marshal to the UI thread to activate the window.
-        _window?.DispatcherQueue.TryEnqueue(() => _window?.Activate());
+        // Raised on a background thread; marshal to the UI thread to activate the window, and — if
+        // this activation came from a Jump List preset (issue #10) — open that preset in the already-
+        // running instance (the redirect carries the launch arguments).
+        _window?.DispatcherQueue.TryEnqueue(() =>
+        {
+            _window?.Activate();
+
+            var openArchivePath = TaskbarJumpList.TryGetOpenArchivePath(e);
+            if (openArchivePath is not null && _window is MainWindow mw)
+            {
+                mw.RequestOpenArchive(openArchivePath);
+            }
+        });
 }

--- a/HostsFileEditor.WinUI/App.xaml.cs
+++ b/HostsFileEditor.WinUI/App.xaml.cs
@@ -123,6 +123,14 @@ public partial class App : Application
             {
                 _window?.Activate();
 
+                // Window.Activate() alone doesn't steal foreground from another app's window (the
+                // Windows foreground lock), so a redirect that arrives while the app is behind another
+                // window would load the preset but not surface. Force it to the front.
+                if (_window is not null)
+                {
+                    BringWindowToForeground(_window);
+                }
+
                 if (openArchivePath is not null && _window is MainWindow mw)
                 {
                     mw.RequestOpenArchive(openArchivePath);
@@ -134,4 +142,76 @@ public partial class App : Application
             }
         });
     }
+
+    // Brings the window to the foreground, working around the Windows foreground lock (SetForegroundWindow
+    // is ignored for a background process unless it briefly attaches to the current foreground thread's
+    // input queue). Restores it first if minimized.
+    private static void BringWindowToForeground(Window window)
+    {
+        var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(window);
+        if (hwnd == IntPtr.Zero)
+        {
+            return;
+        }
+
+        if (IsIconic(hwnd))
+        {
+            _ = ShowWindow(hwnd, SwRestore);
+        }
+
+        var foregroundThread = GetWindowThreadProcessId(GetForegroundWindow(), out _);
+        var currentThread = GetCurrentThreadId();
+
+        if (foregroundThread != 0 && foregroundThread != currentThread)
+        {
+            _ = AttachThreadInput(foregroundThread, currentThread, true);
+            _ = BringWindowToTop(hwnd);
+            _ = SetForegroundWindow(hwnd);
+            _ = AttachThreadInput(foregroundThread, currentThread, false);
+        }
+        else
+        {
+            _ = BringWindowToTop(hwnd);
+            _ = SetForegroundWindow(hwnd);
+        }
+    }
+
+    private const int SwRestore = 9;
+
+    [LibraryImport("user32.dll")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    private static partial IntPtr GetForegroundWindow();
+
+    [LibraryImport("user32.dll")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    private static partial uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
+
+    [LibraryImport("kernel32.dll")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    private static partial uint GetCurrentThreadId();
+
+    [LibraryImport("user32.dll")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool AttachThreadInput(uint idAttach, uint idAttachTo, [MarshalAs(UnmanagedType.Bool)] bool fAttach);
+
+    [LibraryImport("user32.dll")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool BringWindowToTop(IntPtr hWnd);
+
+    [LibraryImport("user32.dll")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool SetForegroundWindow(IntPtr hWnd);
+
+    [LibraryImport("user32.dll")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool ShowWindow(IntPtr hWnd, int nCmdShow);
+
+    [LibraryImport("user32.dll")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool IsIconic(IntPtr hWnd);
 }

--- a/HostsFileEditor.WinUI/App.xaml.cs
+++ b/HostsFileEditor.WinUI/App.xaml.cs
@@ -101,18 +101,37 @@ public partial class App : Application
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
     private static partial int CoWaitForMultipleObjects(uint dwFlags, uint dwMilliseconds, uint nHandles, IntPtr[] pHandles, out uint lpdwIndex);
 
-    private void OnInstanceActivated(object? sender, AppActivationArguments e) =>
-        // Raised on a background thread; marshal to the UI thread to activate the window, and — if
-        // this activation came from a Jump List preset (issue #10) — open that preset in the already-
-        // running instance (the redirect carries the launch arguments).
+    private void OnInstanceActivated(object? sender, AppActivationArguments e)
+    {
+        // Raised on a BACKGROUND thread. Read the archive path from the activation args HERE — the
+        // AppActivationArguments (and its .Data) is an apartment-bound COM object created on this
+        // thread; touching it from the UI thread throws (and crashed the running instance). Marshal
+        // only the resulting string to the UI thread.
+        string? openArchivePath = null;
+        try
+        {
+            openArchivePath = TaskbarJumpList.TryGetOpenArchivePath(e);
+        }
+        catch (Exception ex)
+        {
+            TaskbarJumpList.Log($"OnInstanceActivated (extract) failed: {ex}");
+        }
+
         _window?.DispatcherQueue.TryEnqueue(() =>
         {
-            _window?.Activate();
-
-            var openArchivePath = TaskbarJumpList.TryGetOpenArchivePath(e);
-            if (openArchivePath is not null && _window is MainWindow mw)
+            try
             {
-                mw.RequestOpenArchive(openArchivePath);
+                _window?.Activate();
+
+                if (openArchivePath is not null && _window is MainWindow mw)
+                {
+                    mw.RequestOpenArchive(openArchivePath);
+                }
+            }
+            catch (Exception ex)
+            {
+                TaskbarJumpList.Log($"OnInstanceActivated (open) failed: {ex}");
             }
         });
+    }
 }

--- a/HostsFileEditor.WinUI/App.xaml.cs
+++ b/HostsFileEditor.WinUI/App.xaml.cs
@@ -2,6 +2,7 @@ using HostsFileEditor.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Xaml;
 using Microsoft.Windows.AppLifecycle;
+using System.Runtime.InteropServices;
 
 namespace HostsFileEditor;
 
@@ -61,18 +62,44 @@ public partial class App : Application
         _window.Activate();
     }
 
-    // Performs the cross-process activation redirect on a thread-pool thread and blocks this
-    // (soon-to-exit) instance until it completes — never on the UI/STA thread (see OnLaunched).
+    // Performs the cross-process activation redirect on a thread-pool thread while THIS (STA) thread
+    // waits with CoWaitForMultipleObjects — a COM-aware wait that keeps pumping the STA message loop.
+    // A plain blocking wait (SemaphoreSlim/WaitHandle) would stall the STA pump, and the redirect is a
+    // cross-apartment COM call that needs it — so it would deadlock (the running instance never gets
+    // the activation and hangs). This is the pattern from Microsoft's WinUI single-instance sample.
     private static void RedirectActivationTo(AppActivationArguments args, AppInstance keyInstance)
     {
-        using var redirected = new SemaphoreSlim(0, 1);
+        var redirectDone = CreateEventW(IntPtr.Zero, bManualReset: true, bInitialState: false, lpName: null);
         _ = Task.Run(() =>
         {
             keyInstance.RedirectActivationToAsync(args).AsTask().GetAwaiter().GetResult();
-            redirected.Release();
+            SetEvent(redirectDone);
         });
-        redirected.Wait();
+
+        _ = CoWaitForMultipleObjects(CwmoDefault, Infinite, 1, [redirectDone], out _);
+        CloseHandle(redirectDone);
     }
+
+    private const uint CwmoDefault = 0;
+    private const uint Infinite = 0xFFFFFFFF;
+
+    [LibraryImport("kernel32.dll", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    private static partial IntPtr CreateEventW(IntPtr lpEventAttributes, [MarshalAs(UnmanagedType.Bool)] bool bManualReset, [MarshalAs(UnmanagedType.Bool)] bool bInitialState, string? lpName);
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool SetEvent(IntPtr hEvent);
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool CloseHandle(IntPtr hObject);
+
+    [LibraryImport("ole32.dll")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    private static partial int CoWaitForMultipleObjects(uint dwFlags, uint dwMilliseconds, uint nHandles, IntPtr[] pHandles, out uint lpdwIndex);
 
     private void OnInstanceActivated(object? sender, AppActivationArguments e) =>
         // Raised on a background thread; marshal to the UI thread to activate the window, and — if

--- a/HostsFileEditor.WinUI/HostsFileEditor.WinUI.csproj
+++ b/HostsFileEditor.WinUI/HostsFileEditor.WinUI.csproj
@@ -60,6 +60,18 @@
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.2.0" />
     <PackageReference Include="H.NotifyIcon.WinUI" Version="2.4.1" />
     <PackageReference Include="System.Resources.Extensions" Version="10.0.9" />
+    <!-- Taskbar JumpList support (issue #10). NOTE: this is an old COM-interop library; see the
+         TrimmerRootAssembly below and the PR notes for the AOT/trim + packaged-identity caveats. -->
+    <PackageReference Include="WindowsAPICodePackCore" Version="8.0.15.2" />
+    <PackageReference Include="WindowsAPICodePackShell" Version="8.0.15.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Root the COM-interop jump-list assemblies so the trimmer doesn't strip members reached only
+         through COM/reflection (issue #10). This does NOT guarantee AOT compatibility — see the PR
+         notes: the modern packaged/AOT publish for the jump list is unverified and may need AOT
+         disabled or the UWP Windows.UI.StartScreen.JumpList API instead. -->
+    <TrimmerRootAssembly Include="Microsoft.WindowsAPICodePack.Core" />
+    <TrimmerRootAssembly Include="Microsoft.WindowsAPICodePack.Shell" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\HostsFileEditor.Core\HostsFileEditor.Core.csproj" />

--- a/HostsFileEditor.WinUI/HostsFileEditor.WinUI.csproj
+++ b/HostsFileEditor.WinUI/HostsFileEditor.WinUI.csproj
@@ -60,18 +60,10 @@
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.2.0" />
     <PackageReference Include="H.NotifyIcon.WinUI" Version="2.4.1" />
     <PackageReference Include="System.Resources.Extensions" Version="10.0.9" />
-    <!-- Taskbar JumpList support (issue #10). NOTE: this is an old COM-interop library; see the
-         TrimmerRootAssembly below and the PR notes for the AOT/trim + packaged-identity caveats. -->
-    <PackageReference Include="WindowsAPICodePackCore" Version="8.0.15.2" />
-    <PackageReference Include="WindowsAPICodePackShell" Version="8.0.15.2" />
-  </ItemGroup>
-  <ItemGroup>
-    <!-- Root the COM-interop jump-list assemblies so the trimmer doesn't strip members reached only
-         through COM/reflection (issue #10). This does NOT guarantee AOT compatibility — see the PR
-         notes: the modern packaged/AOT publish for the jump list is unverified and may need AOT
-         disabled or the UWP Windows.UI.StartScreen.JumpList API instead. -->
-    <TrimmerRootAssembly Include="Microsoft.WindowsAPICodePack.Core" />
-    <TrimmerRootAssembly Include="Microsoft.WindowsAPICodePack.Shell" />
+    <!-- Taskbar Jump List (issue #10) uses the WinRT Windows.UI.StartScreen.JumpList API — packaged-
+         native and AOT-compatible via CsWinRT — not WindowsAPICodePack (that library is pure COM
+         interop and fails Native AOT: `IL3052 COM interop is not supported`). Classic, which does not
+         AOT, still uses WindowsAPICodePack. -->
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\HostsFileEditor.Core\HostsFileEditor.Core.csproj" />

--- a/HostsFileEditor.WinUI/MainWindow.xaml.cs
+++ b/HostsFileEditor.WinUI/MainWindow.xaml.cs
@@ -377,7 +377,6 @@ public sealed partial class MainWindow : Window, INotifyPropertyChanged
         }
         catch (Exception ex)
         {
-            TaskbarJumpList.Log($"ImportArchiveFromJumpListAsync failed: {ex}");
             if (!_isClosed)
             {
                 await ShowErrorDialogAsync("Error Opening Preset", $"An error occurred while opening the preset:\n\n{ex.Message}");

--- a/HostsFileEditor.WinUI/MainWindow.xaml.cs
+++ b/HostsFileEditor.WinUI/MainWindow.xaml.cs
@@ -349,27 +349,40 @@ public sealed partial class MainWindow : Window, INotifyPropertyChanged
 
     private async Task ImportArchiveFromJumpListAsync(string archivePath)
     {
-        if (_isClosed || !File.Exists(archivePath))
+        // Fire-and-forget from the activation path — catch everything so a failure is logged, not
+        // silently swallowed (or crashing the app).
+        try
         {
-            return;
-        }
-
-        // Opening a preset replaces the current entries, so warn before discarding unsaved edits.
-        if (HostsFile.Instance.IsModified)
-        {
-            var confirmed = await ShowConfirmationAsync(
-                "Open preset?",
-                "You have unsaved changes to the hosts file that will be lost. Open the preset anyway?",
-                primaryText: "Open preset",
-                closeText: "Cancel");
-
-            if (!confirmed || _isClosed)
+            if (_isClosed || !File.Exists(archivePath))
             {
                 return;
             }
-        }
 
-        await MutateCoreAndRefreshAsync(() => HostsFile.Instance.Import(archivePath));
+            // Opening a preset replaces the current entries, so warn before discarding unsaved edits.
+            if (HostsFile.Instance.IsModified)
+            {
+                var confirmed = await ShowConfirmationAsync(
+                    "Open preset?",
+                    "You have unsaved changes to the hosts file that will be lost. Open the preset anyway?",
+                    primaryText: "Open preset",
+                    closeText: "Cancel");
+
+                if (!confirmed || _isClosed)
+                {
+                    return;
+                }
+            }
+
+            await MutateCoreAndRefreshAsync(() => HostsFile.Instance.Import(archivePath));
+        }
+        catch (Exception ex)
+        {
+            TaskbarJumpList.Log($"ImportArchiveFromJumpListAsync failed: {ex}");
+            if (!_isClosed)
+            {
+                await ShowErrorDialogAsync("Error Opening Preset", $"An error occurred while opening the preset:\n\n{ex.Message}");
+            }
+        }
     }
 
     // One-shot bulk load of the (filtered) entries: build the list off the persistent collection

--- a/HostsFileEditor.WinUI/MainWindow.xaml.cs
+++ b/HostsFileEditor.WinUI/MainWindow.xaml.cs
@@ -354,6 +354,21 @@ public sealed partial class MainWindow : Window, INotifyPropertyChanged
             return;
         }
 
+        // Opening a preset replaces the current entries, so warn before discarding unsaved edits.
+        if (HostsFile.Instance.IsModified)
+        {
+            var confirmed = await ShowConfirmationAsync(
+                "Open preset?",
+                "You have unsaved changes to the hosts file that will be lost. Open the preset anyway?",
+                primaryText: "Open preset",
+                closeText: "Cancel");
+
+            if (!confirmed || _isClosed)
+            {
+                return;
+            }
+        }
+
         await MutateCoreAndRefreshAsync(() => HostsFile.Instance.Import(archivePath));
     }
 

--- a/HostsFileEditor.WinUI/MainWindow.xaml.cs
+++ b/HostsFileEditor.WinUI/MainWindow.xaml.cs
@@ -308,18 +308,53 @@ public sealed partial class MainWindow : Window, INotifyPropertyChanged
         OnPropertyChanged(nameof(IsEntriesInteractive));
 
         // Taskbar Jump List (issue #10): publish the current presets and keep it in sync as archives
-        // change.
-        TaskbarJumpList.Refresh();
-        HostsArchiveList.Instance.ListChanged += (s, e) => TaskbarJumpList.Refresh();
+        // change. Fire-and-forget — RefreshAsync no-ops when unpackaged (JumpList needs identity).
+        _ = TaskbarJumpList.RefreshAsync();
+        HostsArchiveList.Instance.ListChanged += (s, e) => _ = TaskbarJumpList.RefreshAsync();
 
-        // If launched from a Jump List entry (--open-archive "<path>"), import that preset into the
-        // editor. Fresh-launch only; a launch while already running is handled by single-instance
-        // redirection, which would need the path forwarded through that channel — see the PR notes.
-        var openArchivePath = TaskbarJumpList.TryGetOpenArchivePath(Environment.GetCommandLineArgs());
-        if (!string.IsNullOrEmpty(openArchivePath) && File.Exists(openArchivePath))
+        // If a Jump List activation arrived before the load finished, honor it now.
+        if (_pendingJumpListArchive is { } pending)
         {
-            await MutateCoreAndRefreshAsync(() => HostsFile.Instance.Import(openArchivePath));
+            _pendingJumpListArchive = null;
+            await ImportArchiveFromJumpListAsync(pending);
         }
+    }
+
+    // Set by RequestOpenArchive when a Jump List activation arrives before the initial load completes;
+    // LoadEntriesAsync imports it once loaded.
+    private string? _pendingJumpListArchive;
+
+    /// <summary>
+    /// Opens the preset a taskbar Jump List entry pointed at (issue #10) — called by App on both a
+    /// fresh launch and a redirect to this already-running instance. If the initial load is still in
+    /// flight, the request is deferred until it completes. Must be called on the UI thread.
+    /// </summary>
+    public void RequestOpenArchive(string archivePath)
+    {
+        if (_isClosed || string.IsNullOrEmpty(archivePath))
+        {
+            return;
+        }
+
+        if (_isLoaded)
+        {
+            _ = ImportArchiveFromJumpListAsync(archivePath);
+        }
+        else
+        {
+            // Loading (or reloading) — remember it; LoadEntriesAsync will pick it up.
+            _pendingJumpListArchive = archivePath;
+        }
+    }
+
+    private async Task ImportArchiveFromJumpListAsync(string archivePath)
+    {
+        if (_isClosed || !File.Exists(archivePath))
+        {
+            return;
+        }
+
+        await MutateCoreAndRefreshAsync(() => HostsFile.Instance.Import(archivePath));
     }
 
     // One-shot bulk load of the (filtered) entries: build the list off the persistent collection

--- a/HostsFileEditor.WinUI/MainWindow.xaml.cs
+++ b/HostsFileEditor.WinUI/MainWindow.xaml.cs
@@ -306,6 +306,20 @@ public sealed partial class MainWindow : Window, INotifyPropertyChanged
         RefreshEntriesFiltered();
         OnPropertyChanged(nameof(LoadingVisibility));
         OnPropertyChanged(nameof(IsEntriesInteractive));
+
+        // Taskbar Jump List (issue #10): publish the current presets and keep it in sync as archives
+        // change.
+        TaskbarJumpList.Refresh();
+        HostsArchiveList.Instance.ListChanged += (s, e) => TaskbarJumpList.Refresh();
+
+        // If launched from a Jump List entry (--open-archive "<path>"), import that preset into the
+        // editor. Fresh-launch only; a launch while already running is handled by single-instance
+        // redirection, which would need the path forwarded through that channel — see the PR notes.
+        var openArchivePath = TaskbarJumpList.TryGetOpenArchivePath(Environment.GetCommandLineArgs());
+        if (!string.IsNullOrEmpty(openArchivePath) && File.Exists(openArchivePath))
+        {
+            await MutateCoreAndRefreshAsync(() => HostsFile.Instance.Import(openArchivePath));
+        }
     }
 
     // One-shot bulk load of the (filtered) entries: build the list off the persistent collection

--- a/HostsFileEditor.WinUI/TaskbarJumpList.cs
+++ b/HostsFileEditor.WinUI/TaskbarJumpList.cs
@@ -46,6 +46,11 @@ internal static class TaskbarJumpList
             {
                 var item = JumpListItem.CreateWithArguments($"{OpenArchivePrefix}{archive.FilePath}", archive.FileName);
                 item.GroupName = PresetsCategory;
+
+                // Show the app icon instead of the default blank-document glyph. A packaged
+                // ms-appx:/// asset; the resource loader picks the right scale/target-size variant.
+                item.Logo = new Uri("ms-appx:///Assets/Square44x44Logo.png");
+
                 jumpList.Items.Add(item);
             }
 

--- a/HostsFileEditor.WinUI/TaskbarJumpList.cs
+++ b/HostsFileEditor.WinUI/TaskbarJumpList.cs
@@ -83,23 +83,4 @@ internal static class TaskbarJumpList
         !string.IsNullOrEmpty(arguments) && arguments.StartsWith(OpenArchivePrefix, StringComparison.Ordinal)
             ? arguments[OpenArchivePrefix.Length..]
             : null;
-
-    /// <summary>
-    /// Appends a diagnostic line to a jump-list log under the per-user data dir. Best-effort; used to
-    /// capture failures in the fire-and-forget activation/import path that would otherwise be invisible.
-    /// </summary>
-    public static void Log(string message)
-    {
-        try
-        {
-            Directory.CreateDirectory(HostsFile.AppDataDirectory);
-            File.AppendAllText(
-                Path.Combine(HostsFile.AppDataDirectory, "jumplist.log"),
-                $"{DateTime.Now:O} {message}{Environment.NewLine}");
-        }
-        catch (Exception)
-        {
-            // Logging is best-effort.
-        }
-    }
 }

--- a/HostsFileEditor.WinUI/TaskbarJumpList.cs
+++ b/HostsFileEditor.WinUI/TaskbarJumpList.cs
@@ -1,0 +1,80 @@
+using Microsoft.WindowsAPICodePack.Shell;
+using Microsoft.WindowsAPICodePack.Taskbar;
+
+namespace HostsFileEditor;
+
+/// <summary>
+/// Populates the Windows taskbar Jump List with the saved archives/presets (issue #10), so the user
+/// can right-click the taskbar icon and open a preset. Each entry relaunches the app with
+/// <see cref="OpenArchiveSwitch"/> "&lt;path&gt;", which the startup path imports into the editor.
+/// Best-effort: any failure is swallowed. See the PR notes for the packaged-identity / AOT caveats of
+/// using the Win32 jump-list API from a packaged WinUI app.
+/// </summary>
+internal static class TaskbarJumpList
+{
+    /// <summary>Command-line switch a jump-list entry passes to open a preset in the editor.</summary>
+    public const string OpenArchiveSwitch = "--open-archive";
+
+    private const string PresetsCategory = "Presets";
+
+    public static void Refresh()
+    {
+        if (!TaskbarManager.IsPlatformSupported)
+        {
+            return;
+        }
+
+        var exePath = Environment.ProcessPath;
+        if (string.IsNullOrEmpty(exePath))
+        {
+            return;
+        }
+
+        try
+        {
+            var jumpList = JumpList.CreateJumpList();
+
+            var archives = HostsArchiveList.Instance
+                .OrderBy(a => a.FileName, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            if (archives.Count > 0)
+            {
+                var category = new JumpListCustomCategory(PresetsCategory);
+                foreach (var archive in archives)
+                {
+                    category.AddJumpListItems(new JumpListLink(exePath, archive.FileName)
+                    {
+                        Arguments = $"{OpenArchiveSwitch} \"{archive.FilePath}\"",
+                        IconReference = new IconReference(exePath, 0),
+                    });
+                }
+
+                jumpList.AddCustomCategories(category);
+            }
+
+            jumpList.Refresh();
+        }
+        catch (Exception)
+        {
+            // Jump list is a convenience; never let a shell/COM failure take down the app.
+        }
+    }
+
+    /// <summary>
+    /// Extracts the archive path from a <see cref="OpenArchiveSwitch"/> "&lt;path&gt;" argument pair,
+    /// or <see langword="null"/> if not present.
+    /// </summary>
+    public static string? TryGetOpenArchivePath(string[] args)
+    {
+        for (var i = 0; i < args.Length - 1; i++)
+        {
+            if (string.Equals(args[i], OpenArchiveSwitch, StringComparison.OrdinalIgnoreCase))
+            {
+                return args[i + 1];
+            }
+        }
+
+        return null;
+    }
+}

--- a/HostsFileEditor.WinUI/TaskbarJumpList.cs
+++ b/HostsFileEditor.WinUI/TaskbarJumpList.cs
@@ -83,4 +83,23 @@ internal static class TaskbarJumpList
         !string.IsNullOrEmpty(arguments) && arguments.StartsWith(OpenArchivePrefix, StringComparison.Ordinal)
             ? arguments[OpenArchivePrefix.Length..]
             : null;
+
+    /// <summary>
+    /// Appends a diagnostic line to a jump-list log under the per-user data dir. Best-effort; used to
+    /// capture failures in the fire-and-forget activation/import path that would otherwise be invisible.
+    /// </summary>
+    public static void Log(string message)
+    {
+        try
+        {
+            Directory.CreateDirectory(HostsFile.AppDataDirectory);
+            File.AppendAllText(
+                Path.Combine(HostsFile.AppDataDirectory, "jumplist.log"),
+                $"{DateTime.Now:O} {message}{Environment.NewLine}");
+        }
+        catch (Exception)
+        {
+            // Logging is best-effort.
+        }
+    }
 }

--- a/HostsFileEditor.WinUI/TaskbarJumpList.cs
+++ b/HostsFileEditor.WinUI/TaskbarJumpList.cs
@@ -1,80 +1,81 @@
-using Microsoft.WindowsAPICodePack.Shell;
-using Microsoft.WindowsAPICodePack.Taskbar;
+using Microsoft.Windows.AppLifecycle;
+using Windows.ApplicationModel.Activation;
+using Windows.UI.StartScreen;
 
 namespace HostsFileEditor;
 
 /// <summary>
-/// Populates the Windows taskbar Jump List with the saved archives/presets (issue #10), so the user
-/// can right-click the taskbar icon and open a preset. Each entry relaunches the app with
-/// <see cref="OpenArchiveSwitch"/> "&lt;path&gt;", which the startup path imports into the editor.
-/// Best-effort: any failure is swallowed. See the PR notes for the packaged-identity / AOT caveats of
-/// using the Win32 jump-list API from a packaged WinUI app.
+/// Populates the Windows taskbar Jump List with the saved archives/presets (issue #10) using the
+/// packaged-native WinRT <see cref="JumpList"/> API (AOT-compatible via CsWinRT, unlike the COM-based
+/// WindowsAPICodePack the classic edition uses). Each entry carries an <see cref="OpenArchivePrefix"/>
+/// argument; the app is re-activated with that argument (fresh launch OR redirected to the running
+/// instance — see App.OnLaunched / OnInstanceActivated) and imports the preset into the editor.
+/// <para>
+/// <see cref="JumpList"/> requires package identity, so <see cref="JumpList.IsSupported"/> is false
+/// for an unpackaged (dev) run and every call here no-ops — the jump list only appears for the
+/// installed MSIX. Best-effort throughout: a WinRT failure never surfaces to the user.
+/// </para>
 /// </summary>
 internal static class TaskbarJumpList
 {
-    /// <summary>Command-line switch a jump-list entry passes to open a preset in the editor.</summary>
-    public const string OpenArchiveSwitch = "--open-archive";
+    /// <summary>Prefix on the launch argument a jump-list entry passes to open a preset.</summary>
+    public const string OpenArchivePrefix = "open-archive:";
 
     private const string PresetsCategory = "Presets";
 
-    public static void Refresh()
+    public static async Task RefreshAsync()
     {
-        if (!TaskbarManager.IsPlatformSupported)
-        {
-            return;
-        }
-
-        var exePath = Environment.ProcessPath;
-        if (string.IsNullOrEmpty(exePath))
+        if (!JumpList.IsSupported())
         {
             return;
         }
 
         try
         {
-            var jumpList = JumpList.CreateJumpList();
+            var jumpList = await JumpList.LoadCurrentAsync();
+
+            // We own the whole list (no recent/frequent system group), so rebuild it from scratch.
+            jumpList.SystemGroupKind = JumpListSystemGroupKind.None;
+            jumpList.Items.Clear();
 
             var archives = HostsArchiveList.Instance
                 .OrderBy(a => a.FileName, StringComparer.OrdinalIgnoreCase)
                 .ToList();
 
-            if (archives.Count > 0)
+            foreach (var archive in archives)
             {
-                var category = new JumpListCustomCategory(PresetsCategory);
-                foreach (var archive in archives)
-                {
-                    category.AddJumpListItems(new JumpListLink(exePath, archive.FileName)
-                    {
-                        Arguments = $"{OpenArchiveSwitch} \"{archive.FilePath}\"",
-                        IconReference = new IconReference(exePath, 0),
-                    });
-                }
-
-                jumpList.AddCustomCategories(category);
+                var item = JumpListItem.CreateWithArguments($"{OpenArchivePrefix}{archive.FilePath}", archive.FileName);
+                item.GroupName = PresetsCategory;
+                jumpList.Items.Add(item);
             }
 
-            jumpList.Refresh();
+            await jumpList.SaveAsync();
         }
         catch (Exception)
         {
-            // Jump list is a convenience; never let a shell/COM failure take down the app.
+            // Jump list is a convenience; never let a WinRT failure take down the app.
         }
     }
 
     /// <summary>
-    /// Extracts the archive path from a <see cref="OpenArchiveSwitch"/> "&lt;path&gt;" argument pair,
-    /// or <see langword="null"/> if not present.
+    /// Extracts the archive path from a jump-list activation, or <see langword="null"/> if the
+    /// activation is not an open-preset launch. Handles both the fresh-launch and redirected-to-
+    /// running-instance activations (both are <see cref="ExtendedActivationKind.Launch"/>).
     /// </summary>
-    public static string? TryGetOpenArchivePath(string[] args)
+    public static string? TryGetOpenArchivePath(AppActivationArguments? args)
     {
-        for (var i = 0; i < args.Length - 1; i++)
+        if (args?.Kind == ExtendedActivationKind.Launch &&
+            args.Data is ILaunchActivatedEventArgs launch)
         {
-            if (string.Equals(args[i], OpenArchiveSwitch, StringComparison.OrdinalIgnoreCase))
-            {
-                return args[i + 1];
-            }
+            return TryGetOpenArchivePath(launch.Arguments);
         }
 
         return null;
     }
+
+    /// <summary>Extracts the archive path from a raw launch-argument string.</summary>
+    public static string? TryGetOpenArchivePath(string? arguments) =>
+        !string.IsNullOrEmpty(arguments) && arguments.StartsWith(OpenArchivePrefix, StringComparison.Ordinal)
+            ? arguments[OpenArchivePrefix.Length..]
+            : null;
 }


### PR DESCRIPTION
Closes #10. **Manually tested and working end-to-end on both editions.**

Right-click the taskbar icon → a **Presets** category lists your saved archives → click one to open it in the editor (review, then Save). Works whether the app is closed or already running.

## How

**Modern (WinUI 3):** the WinRT **`Windows.UI.StartScreen.JumpList`** API — packaged-native and **AOT-clean** (0 ILC errors). Items carry an `open-archive:<path>` argument and the app icon (`JumpListItem.Logo`).

**Classic (WinForms):** the Win32 jump list via **WindowsAPICodePack** (`JumpListLink` with `--open-archive "<path>"`). This is the right tool here — see below.

Both editions:
- Rebuild the list on load and whenever the archive list changes (best-effort; never crashes the app).
- **Open the preset in the already-running instance** (not a second window), and **warn if there are unsaved changes** before replacing the current entries (Save / Don't save / Cancel).
- Are non-destructive: opening a preset imports it into the editor; it does not auto-write the hosts file.

### Why WindowsAPICodePack for classic but the WinRT API for modern
The modern app is `PublishAot=true`, and WindowsAPICodePack is **categorically AOT-incompatible** — an AOT publish with it produced **555 ILC errors** ending in `IL3052: COM interop is not supported with full ahead-of-time compilation` (it's pure COM interop and drags in PresentationFramework/XPS). The WinRT `JumpList` API AOT-compiles cleanly via CsWinRT. Classic doesn't AOT (WinForms), so WindowsAPICodePack — the natural Win32 jump-list wrapper for an unpackaged exe — is fine there.

### How the launch reaches the app
- **Modern** launches arrive as an **activation argument**: `App.OnLaunched` (fresh) and `OnInstanceActivated` (redirected to the running instance) extract the path and call `MainWindow.RequestOpenArchive`.
- **Classic** passes `--open-archive` on the command line; a second instance drops the path in a hand-off file and signals the running instance via the existing single-instance broadcast (which carries no payload of its own).

## Latent single-instance bugs this fixed along the way
The jump list is the first feature to actually exercise the modern app's activation-redirect path, which surfaced three pre-existing bugs — all now fixed (and they also fix "bring the existing window to the front when a second copy is launched"):
1. **Redirect deadlock** — `RedirectActivationToAsync(...).GetResult()` blocked the STA UI thread; the redirect (a cross-apartment COM call) needs that thread to keep pumping. Fixed with `CoWaitForMultipleObjects` (pumps while waiting), the pattern from Microsoft's single-instance sample.
2. **Cross-thread crash** — the activation args (`e.Data`, an apartment-bound COM object created on the background `Activated` thread) were read from the UI thread. Now extracted on the activation thread; only the string is marshaled.
3. **Foreground lock** — `Window.Activate()` can't steal foreground from another app's window, so a preset opened behind another window didn't surface. Fixed with `SetForegroundWindow` via `AttachThreadInput` (+ restore if minimized).

## Decisions
- **Action = import into the editor**, not apply-and-save — a taskbar click silently rewriting the system hosts file felt too dangerous.
- **`--open-archive` (import) is distinct from #2's `-s` (apply + save headlessly).** If both land, worth unifying the launch verb.
- Classic's running-instance hand-off uses a small file rather than WM_COPYDATA — simpler, and it composes with the existing broadcast.

## Verification
- **Manually tested on both editions:** jump list appears with the right presets + app icon; clicking opens the preset; already-running open works; unsaved-changes warning works; the window comes to the foreground.
- Modern **AOT publish is clean** (0 ILC errors) and the signed MSIX installs and runs.
- Note: signing a local test MSIX needs a cert whose subject matches the manifest Publisher, and the repo's test cert had expired — regenerated in #94 (separate PR).

## Open questions
1. Unify `--open-archive` (this) with `-s` (#2) into one launch verb?
2. Classic running-instance forwarding via a hand-off file vs WM_COPYDATA — preference?
3. Modern jump-list icon uses `Square44x44Logo`; happy to point it at a specific unplated `targetsize` asset if you want a different look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)