### PR TITLE
Release: classic 1.5.0 / modern 1.2.0 — CLI, Jump List, merge, hotkey, sort

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,9 @@ Guidance for working in this repository.
 **Hosts File Editor** — a Windows desktop app for editing the system `hosts` file
 (`%WinDir%\System32\drivers\etc\hosts`). It supports cut/copy/paste/duplicate/enable/disable/move
 of entries, filtering and sorting, enabling/disabling the entire hosts file, archiving and restoring
-hosts-file configurations, and auto-pinging endpoints to check availability.
+hosts-file configurations (presets, also reachable from a taskbar Jump List), merging another hosts
+file with duplicate elimination, auto-pinging endpoints to check availability, and a headless
+command line (`apply`/`enable`/`disable`/`import`/`merge`/`list`) shared by both editions.
 
 The repository is **mid-migration from WinForms to WinUI 3**. Two UIs currently ship side by side on
 top of one shared core library:
@@ -30,6 +32,7 @@ asked otherwise.
 | `HostsFileEditor.WinUI` | WinUI 3 app | `net10.0-windows10.0.19041.0` | "Modern" UI. DI via `Microsoft.Extensions.DependencyInjection`, MSIX/AOT/trimmed publish, x64+arm64. |
 | `HostsFileEditor.WinForm` | WinForms app | `net10.0-windows` | "Classic" UI. Self-contained, ReadyToRun, win-x64. Uses `Equin.ApplicationFramework.BindingListView`. |
 | `HostsFileEditor.Elevate` | Helper exe (no window) | `net10.0-windows` | Tiny `asInvoker` exe launched with the `runas` verb to perform privileged hosts-file writes/moves on demand. Copied into an `Elevate\` subfolder beside each app (AOT-published for packages). |
+| `HostsFileEditor.Cli` | Console exe (`hfe.exe`) | `net10.0-windows` | Console-subsystem launcher for the shared CLI (`Core/CommandLine/HostsCli`) — `cmd`/PowerShell wait for it, unlike the GUI exes. One-line `Main`. AOT-published into each app's publish root (`PublishCliLauncher` targets); MSIX packages register an `hfe` app-execution alias. |
 
 Solution file is **`HostsFileEditor.slnx`** (the new XML solution format). The WinUI project is pinned
 to the `x64` platform in the solution.
@@ -95,16 +98,30 @@ safe to remove.
   `File` ops) and `ElevatedHelper…` (tries direct first, falls back to the `runas` helper on
   access-denied). `PrivilegedFileOperations.Current` is the process-wide gateway; apps call
   `UseElevationHelper()` at startup. `ElevationCancelledException` signals a declined UAC prompt.
-- **`HostsEntry`** (`HostsEntry.cs`) — one line of the hosts file. Regex-parsed into
-  ip/hostnames/comment/enabled/valid. Implements `INotifyPropertyChanged` and `IDataErrorInfo`.
-  Property setters push undo/redo actions onto `UndoManager` (only when the value actually changes).
-  `Ping()` runs on demand and disposes its `Ping` itself, so entries are not `IDisposable`.
-  `UnparsedText` lazily re-serializes when fields change.
+- **`HostsEntry`** (`HostsEntry.cs`) — one line of the hosts file. Span-parsed (regex kept as a
+  differential-test oracle) into ip/hostnames/comment/enabled/valid; entry-ness is gated on a
+  syntactically valid IP first token (`IsValidIpToken`). Implements `INotifyPropertyChanged` and
+  `IDataErrorInfo`. Property setters push undo/redo actions onto `UndoManager` (only when the value
+  actually changes). `Ping()` runs on demand and disposes its `Ping` itself, so entries are not
+  `IDisposable`; a static begin/end ping counter drives `PingActivityChanged` (the UIs' status-bar
+  indicator) and `PingFailed` flags per-entry failures. `UnparsedText` lazily re-serializes when
+  fields change. Also home to the canonical cross-edition helpers: `MatchesFilter` (the one filter
+  predicate) and `GetComparer`/`SortColumn` (the one display-sort comparer; IP sorts numerically via
+  a cached per-entry `IpSortKey`).
 - **`HostsEntryList`** (`HostsEntryList.cs`) — `BindingList<HostsEntry>` with move/insert/remove/
   enable batch operations, all undo-aware. `InsertItem`/`RemoveItem` overrides register undo actions.
-- **`HostsArchive` / `HostsArchiveList`** — named snapshots stored under
+  `MergeLines` appends another file's entries minus duplicates (canonical-IP + hostnames identity)
+  as a single undoable step; `PingAll` pings every entry on demand.
+- **`HostsArchive` / `HostsArchiveList`** — named snapshots ("presets") stored under
   `%LocalAppData%\HostsFileEditor\archive` (migrated once from the legacy `…\drivers\etc\archive`).
-  `HostsArchiveList.Instance` is a singleton `BindingList`.
+  `HostsArchiveList.Instance` is a singleton `BindingList`; `FindByName` resolves a preset name
+  case-insensitively (CLI, Jump List).
+- **`CommandLine/`** — `HostsCli` (verb parser + runner for the headless CLI; hand-rolled, no NuGet,
+  AOT-safe; exit codes 0/1/2) and `ConsoleAttach` (`AttachConsole` so the GUI-subsystem exes can print
+  to the launching console without breaking redirection). Both editions' `Main` route any non-GUI
+  argument here — classic excludes the Jump List's `--open-archive`, modern excludes the
+  `open-archive:` activation prefix. The modern app supplies its own `Program.Main` via
+  `DISABLE_XAML_GENERATED_MAIN` so the CLI runs without booting WinUI.
 - **`UndoManager`** (`Utilities/UndoManager.cs`) — singleton `UndoManager.Instance`. Linked-list of
   linked-lists of `Action`. Supports batching (`BatchActions`), suspension (`SuspendUndo/Redo/
   UndoRedo`), capped history (`MaximumHistorySize`), and raises `HistoryChanged`.
@@ -116,7 +133,17 @@ safe to remove.
 - **`Win32/Win32FileDialogs`** — hand-rolled `comdlg32` open/save dialogs (used by the WinUI app,
   which has no built-in file dialog matching the needs).
 - **`ProgramSingleInstance`** — mutex-based single-instance enforcement (WinForm). The WinUI app uses
-  `AppInstance.FindOrRegisterForKey` instead (`App.xaml.cs`).
+  `AppInstance.FindOrRegisterForKey` instead (`App.xaml.cs`). CLI invocations bypass single-instance
+  (they run headless in their own process and exit).
+
+### Per-edition extras (not in Core)
+
+- **`TaskbarJumpList`** (one per edition, deliberately separate): classic uses WindowsAPICodePack
+  (COM interop — cannot be used in the AOT'd modern app: `IL3052`); modern uses the WinRT
+  `Windows.UI.StartScreen.JumpList` API. Both list the archives as taskbar Jump List entries.
+- **`NativeHotkey` + `MainForm.RegisterGlobalHotkey`** (classic) — global show/hide hot key
+  (`RegisterHotKey`), combo configurable via the `GlobalShowHideHotkey` user setting (default
+  `Control, Shift, H`; blank disables; registration failure shows a one-time guidance popup).
 
 ### Test hooks (do not remove)
 
@@ -143,11 +170,15 @@ Tests are MSTest classes (`[TestClass]`/`[TestMethod]`) using **Shouldly** asser
 
 ## Packaging (Directory.Build.targets)
 
-`dotnet publish` runs a `SignAndPackage` target after publish: signs the exe, builds an MSIX with
-`makeappx`, signs the MSIX, optionally zips, and copies outputs to `artifacts\<flavor>\`. It resolves
-`signtool.exe`/`makeappx.exe` from the Windows SDK via several fallbacks (VS dev shell env vars, then
-registry `KitsRoot10`). Test signing cert is `HostsFileEditorTestCert.pfx` (password `test`) — for
-local/dev only.
+`dotnet publish` runs a `SignAndPackage` target after publish: signs the binaries (app exe, the
+`Elevate` helper, and `hfe.exe`), builds an MSIX with `makeappx`, optionally signs the MSIX
+(`SignPackage=true`, sideload only — needs the manifest Publisher to match the cert subject; see
+`docs/signing.md`), optionally zips, and copies outputs to `artifacts\<flavor>\`. Per-app
+`PublishElevateHelper`/`PublishCliLauncher` targets AOT-publish the helper exes into the publish
+output first, and strip targets delete unused runtime libraries (WPF natives from classic, WinApp SDK
+ML/Widgets libs from modern). Tool paths (`signtool.exe`/`makeappx.exe`) resolve from the Windows SDK
+via several fallbacks (VS dev shell env vars, then registry `KitsRoot10`). Test signing cert is
+`HostsFileEditorTestCert.pfx` (password `test`) — for local/dev only.
 
 ## Gotchas
 

--- a/HostsFileEditor.WinForm/AppxManifest.xml
+++ b/HostsFileEditor.WinForm/AppxManifest.xml
@@ -5,6 +5,9 @@
          xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5"
          xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
          IgnorableNamespaces="uap uap5 mp rescap">
+  <!-- Version below is a PLACEHOLDER: Directory.Build.targets XmlPokes Identity/@Version from the
+       csproj <Version> at pack time. Never `makeappx pack` against this source manifest directly
+       or the package ships with this stale version. -->
   <Identity Name="11033ScottLerch.HostsFileEditorclassic"
             Publisher="CN=427E0D6A-DF11-4676-8850-592258173525"
             Version="1.3.0.0"

--- a/HostsFileEditor.WinForm/HostsFileEditor.WinForm.csproj
+++ b/HostsFileEditor.WinForm/HostsFileEditor.WinForm.csproj
@@ -22,7 +22,7 @@
     <!-- Single version source for this app: drives AssemblyVersion, FileVersion, the exe's
          ProductVersion resource, and (stamped in Directory.Build.targets) the MSIX manifest
          Identity/@Version. ProductVersion is not an SDK-recognized property and was ignored. -->
-    <Version>1.4.1.0</Version>
+    <Version>1.5.0.0</Version>
     <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
     <!-- Native AOT isn't working yet with WinForms, specifically Binding is explicitly not supported throwing NotSupportedException -->
     <!--<PublishAot>true</PublishAot>-->

--- a/HostsFileEditor.WinUI/AppxManifest.xml
+++ b/HostsFileEditor.WinUI/AppxManifest.xml
@@ -5,6 +5,9 @@
          xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5"
          xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
          IgnorableNamespaces="uap uap5 mp rescap">
+  <!-- Version below is a PLACEHOLDER: Directory.Build.targets XmlPokes Identity/@Version from the
+       csproj <Version> at pack time. Never `makeappx pack` against this source manifest directly
+       or the package ships with this stale version. -->
   <Identity Name="11033ScottLerch.HostsFileEditormodern"
             Publisher="CN=427E0D6A-DF11-4676-8850-592258173525"
             Version="1.0.0.0"

--- a/HostsFileEditor.WinUI/HostsFileEditor.WinUI.csproj
+++ b/HostsFileEditor.WinUI/HostsFileEditor.WinUI.csproj
@@ -7,7 +7,7 @@
     <!-- Single version source for this app (the modern UI ships as its own version stream,
          separate from classic). Drives AssemblyVersion/FileVersion/ProductVersion and, stamped
          in Directory.Build.targets, the MSIX manifest Identity/@Version. -->
-    <Version>1.1.1.0</Version>
+    <Version>1.2.0.0</Version>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platform Condition="'$(Platform)' == ''">x64</Platform>
     <Platforms>x64;arm64</Platforms>

--- a/Readme.md
+++ b/Readme.md
@@ -22,8 +22,12 @@ save changes to the hosts file, so day-to-day viewing, archiving, and backups ne
  * Cut, copy, paste, duplicate, enable, disable and move one or more entries at a time
  * Filter and sort when there are a large number of host entries
  * Quickly enable and disable the entire hosts file
- * Archive and restore various hosts file configurations when switching between environments
- * Automatically ping endpoints to check availability
+ * Archive and restore various hosts file configurations (presets) when switching between environments
+ * Merge another hosts file into the current one, skipping duplicates
+ * Automatically ping endpoints to check availability, with a status-bar progress indicator
+ * Switch presets straight from the taskbar &mdash; right-click the app for a Jump List of your archives
+ * Full [command line](#command-line) for scripting: switch presets, enable/disable, import/merge
+ * Global shortcut key (default `Ctrl+Shift+H`) to hide/restore the classic edition from the tray
  * Modern variant supports light and dark themes
 
 ![Main screen classic](images/classic.png)
@@ -40,6 +44,60 @@ When selecting rows to move, delete, copy, or cut be sure to select the entire r
 
 Using the filter and sort while editing is quirky. The filter and sort are applied once a cell is edited so your cell may change positions or disappear depending on the current sort and filter.
 
+## Command line
+
+Both editions include a headless command line (v1.5.0 classic / v1.2.0 modern) so scripts can switch
+presets and toggle the hosts file &mdash; for example, applying a preset before launching a program and
+restoring it afterward:
+
+```bat
+hfe -s MyHosts1
+program.exe
+hfe -s DefaultHosts
+```
+
+### Commands
+
+| Command | Effect |
+|---|---|
+| `apply <preset>` (alias `-s`, `switch`) | Switch the hosts file to a saved preset (archive) |
+| `enable` | Enable the hosts file |
+| `disable` | Disable the hosts file (renames it aside) |
+| `import <file>` | Replace the hosts file with `<file>`, then save |
+| `merge <file>` | Merge `<file>` into the hosts file, skipping duplicates, then save |
+| `list` | List available presets |
+| `help` (`--help`, `-h`) | Show usage |
+
+Presets are the archives you save in the app (the **Archive** feature); `apply` matches the archive
+name case-insensitively, with or without its file extension.
+
+**Exit codes:** `0` success &middot; `1` runtime error (preset or file not found, permission declined)
+&middot; `2` usage error (unknown or malformed command). Errors print a one-line message to stderr.
+
+### `hfe.exe` vs `HostsFileEditor.exe`
+
+Two executables run the same commands:
+
+* **`hfe.exe`** &mdash; a small console launcher that ships next to the app. **Use this in scripts**:
+  it is a console app, so `cmd` and PowerShell wait for it to finish before running the next line, and
+  its output pipes/redirects naturally. Store installs also register `hfe` on `PATH` (an app-execution
+  alias), so `hfe -s MyHosts1` works from any console.
+* **`HostsFileEditor.exe`** &mdash; the app itself also accepts the same commands and runs them headless
+  (no window). Because it is a windowed app, `cmd` does *not* wait for it &mdash; wrap it as
+  `start /wait "" HostsFileEditor.exe -s MyHosts1` for sequential steps, or just use `hfe.exe`.
+
+Run with no command and the app opens normally.
+
+### Permissions
+
+Commands that change the hosts file need administrator rights, exactly like saving in the GUI: run
+from an elevated console for silent operation, or accept the single UAC prompt per command. A declined
+prompt cancels cleanly with exit code `1`. `list` and `help` never need elevation.
+
+Note: the CLI runs independently of an open GUI window &mdash; if the editor is open with unsaved
+changes, a CLI change to the hosts file isn't reflected there until you refresh (F5), and saving stale
+GUI edits afterward overwrites the CLI's change (last writer wins).
+
 ## Download
 
 Runs on Windows 10 and 11, x64 or ARM64. Two editions are available &mdash; pick whichever you prefer;
@@ -52,12 +110,14 @@ Installs and updates automatically, with no separate download:
  * [Hosts File Editor (modern)](https://apps.microsoft.com/detail/9NBQWCDXGF9R) &mdash; the new WinUI edition
  * [Hosts File Editor (classic)](https://apps.microsoft.com/detail/9NF73PSPK332) &mdash; the classic WinForms edition
 
-### Portable &mdash; v1.4.1
+### Portable &mdash; v1.5.0
 
 The **classic edition** rebuilt on .NET 10: fully self-contained (no runtime to install), runs as a standard user, and elevates on demand (a single UAC prompt) only when you save changes to the hosts file. Binaries are signed. Download directly from [GitHub Releases](https://github.com/scottlerch/HostsFileEditor/releases):
 
- * [Download v1.4.1 portable &mdash; x64](https://github.com/scottlerch/HostsFileEditor/releases/download/v1.4.1/HostsFileEditor-1.4.1-x64.zip)
- * [Download v1.4.1 portable &mdash; ARM64](https://github.com/scottlerch/HostsFileEditor/releases/download/v1.4.1/HostsFileEditor-1.4.1-arm64.zip)
+ * [Download v1.5.0 portable &mdash; x64](https://github.com/scottlerch/HostsFileEditor/releases/download/v1.5.0/HostsFileEditor-1.5.0-x64.zip)
+ * [Download v1.5.0 portable &mdash; ARM64](https://github.com/scottlerch/HostsFileEditor/releases/download/v1.5.0/HostsFileEditor-1.5.0-arm64.zip)
+
+_What's new in v1.5.0 (classic) / v1.2.0 (modern):_ a **feature release**. A full **[command line](#command-line)** in both editions plus a new `hfe.exe` console launcher &mdash; switch presets, enable/disable, import, and merge from scripts (Store installs put `hfe` on `PATH`). A taskbar **Jump List**: right-click the app icon to open any preset directly. **File &rarr; Merge** combines another hosts file into the current one, skipping duplicates (undoable). The modern edition gains **Sort options** next to the filter, and the **IP column now sorts numerically** in both editions (`8.8.8.8` before `10.0.0.2` before `10.0.0.10`, IPv6 after IPv4). **Auto-ping** shows a status-bar progress indicator while pings are in flight, flags per-entry failures (modern gets an error badge with tooltip), and pings immediately when enabled. The classic edition adds a **global shortcut** (default `Ctrl+Shift+H`, configurable) to hide/restore from the tray, its text **filter is now case-insensitive** to match modern, the parser validates IPs strictly at parse time, and the portable zip dropped ~9 MB of unused libraries. See the [full release notes](https://github.com/scottlerch/HostsFileEditor/releases/tag/v1.5.0).
 
 _What's new in v1.4.1:_ a small maintenance patch &mdash; the classic edition no longer targets the wrong entry when you **Insert or Move right after a Move** (the current-row anchor is restored by identity), and the modern edition skips a redundant filter pass on very large selections. See the [full release notes](https://github.com/scottlerch/HostsFileEditor/releases/tag/v1.4.1).
 


### PR DESCRIPTION
Release prep for **classic 1.5.0 / modern 1.2.0** — the feature release bundling the recent issue-batch PRs.

## In this PR

- **Version bump**: classic `1.4.1.0 → 1.5.0.0`, modern `1.1.1.0 → 1.2.0.0` (flows to AssemblyVersion + MSIX `Identity/@Version` at pack time).
- **Readme**: new **Command line** section fully documenting the CLI (commands/presets/exit codes, `hfe.exe` vs the GUI exe, permissions, GUI-coexistence note); Features list refreshed; v1.5.0/v1.2.0 what's-new + portable download links (assets upload on release).
- **CLAUDE.md**: documents the `HostsFileEditor.Cli` project, Core `CommandLine/` + the new canonical helpers (`MatchesFilter`, `GetComparer`/`IpSortKey`, `MergeLines`, `FindByName`, ping counter), per-edition `TaskbarJumpList`/`NativeHotkey`, and the updated packaging pipeline.
- **Manifests**: comment marking `Identity/@Version` as a pack-time-stamped placeholder (release-review follow-up).

## What ships in 1.5.0 / 1.2.0 (since v1.4.1)

| Change | Issue | PR |
|---|---|---|
| Command line (both editions) + `hfe.exe` launcher + MSIX `hfe` alias | #2 | #88 |
| Taskbar Jump List of presets (both editions) | #10 | #93 |
| File → Merge with duplicate elimination (undoable) | #26 | #90 |
| Classic global show/hide hot key (configurable, default Ctrl+Shift+H) | #35 | #91 |
| Modern Sort options + numeric IP sort in both editions | #81 | #92 |
| Ping-in-progress indicator + per-entry failure flag + ping-on-enable | #9 | #89 |
| Unified filter predicate (classic filter now case-insensitive) | #75 | #86 |
| Strict IP-token parser gate | #80 | #84 |
| Modern async-lifecycle state enum (internal) | #76 | #87 |
| Classic anchor/selection-restore fusion (internal) | #77 | #85 |
| Test signing cert regenerated (internal) | — | #94 |
| Classic publish drops ~9 MB unused WPF natives | — | #88 |

## Release-level code review — ✅ NO BLOCKERS

Three review passes over the cumulative v1.4.1→HEAD diff (4,400 lines, 36 files), aimed at what the per-PR reviews couldn't see: **cross-feature interactions**, a **fresh-eyes Core sweep**, and **packaging/Store-cert readiness**. 19 findings, all non-blockers, filed as issues on the **v1.5.1 / v1.2.1** milestone:

- #96 ping-state consistency (stale result marks new IP; clone desync) · #97 merge pings discarded duplicates · #103 ping results racing a background merge/import (potential crash race — prioritize) 
- #99 CLI double-`disable` data-loss edge (prioritize) · #98 ambiguous preset-stem fallback · #100 CLI vs open GUI reconciliation
- #101 modern Jump List preset dropped during reload · #102 classic Jump List blocks UI thread mid-load · #106 classic Jump List versioned-path dead links after Store update
- #104 Paste not sort-gated · #105 `hfe` alias collision/virtualization between editions · #107 missing `Settings.Upgrade()` · #108 hotkey dialog's wrong config path under MSIX

Verified sound by the review: ping counter balance (no stuck indicator), merge undo/redo closures, sort-key invalidation, CLI/Jump-List/single-instance arg routing, the second-Application + `appExecutionAlias` manifests (WACK-valid; residual Store *policy* risk on the hidden app entry is inference — budget one submission round-trip), and the WPF-native strip (single-file exe has no loose-native dependency).

## Pre-submission checklist (before Store upload / GitHub release)

- [ ] `.\build-all.ps1 -Sign` — the current `artifacts\` hold **sideload test packages** (test cert, test publisher, old versions); all four flavor/arch packages must be rebuilt clean.
- [ ] **arm64 smoke test** — the arm64 legs (AOT `hfe.exe` cross-compile, strip targets, signing) haven't been exercised this release.
- [ ] Store submission via `publish-store.ps1` (PR #83 — API healthy as of 2026-07-13, needs your Partner Center secret; What's-new copy already updated for this release).
- [ ] Tag `v1.5.0`, upload the portable zips named `HostsFileEditor-1.5.0-<arch>.zip` (Readme links assume this naming).
- [ ] Close milestone **v1.5.0 / v1.2.0 — minor (features)** (all 9 issues closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
