### PR TITLE
Store fix: visible CLI app entry (hidden entry needs HeadlessAppBypass waiver)

### DIFF
--- a/HostsFileEditor.Cli/Program.cs
+++ b/HostsFileEditor.Cli/Program.cs
@@ -4,4 +4,8 @@ using HostsFileEditor.CommandLine;
 // console app (unlike the GUI-subsystem HostsFileEditor.exe), cmd/PowerShell WAIT for it to exit, so
 // it can be used directly in a sequential script without `start /wait`. It runs the exact same Core
 // CLI as the GUI editions' headless mode, so behavior and exit codes are identical.
-return HostsCli.Run(args, Console.Out, Console.Error);
+//
+// No args → help (exit 0): unlike the GUI exes (where no args opens the window), a bare `hfe` has
+// nothing sensible to do but explain itself — and the Store package's visible "Hosts File Editor CLI"
+// entry launches exactly that way, so a Start-menu click shows usage instead of a usage ERROR.
+return HostsCli.Run(args.Length == 0 ? ["help"] : args, Console.Out, Console.Error);

--- a/HostsFileEditor.WinForm/AppxManifest.xml
+++ b/HostsFileEditor.WinForm/AppxManifest.xml
@@ -39,8 +39,10 @@
         <uap:SplashScreen Image="Assets\Square150x150Logo.png"/>
       </uap:VisualElements>
     </Application>
-    <!-- Console launcher (issue #2): a hidden app entry whose appExecutionAlias puts `hfe` on PATH so
-         scripts can run `hfe -s Preset` etc. AppListEntry="none" keeps it off the Start menu. hfe.exe
+    <!-- Console launcher (issue #2): a second app entry whose appExecutionAlias puts `hfe` on PATH so
+         scripts can run `hfe -s Preset` etc. The entry is VISIBLE in the Start menu app list: hiding it
+         (AppListEntry="none") requires the account-level "HeadlessAppBypass" waiver, without which
+         Store package validation rejects the submission (hit on the 1.5.0/1.2.0 release). hfe.exe
          is console-subsystem, so cmd/PowerShell wait for it. -->
     <Application Id="Cli"
                  Executable="hfe.exe"
@@ -48,7 +50,6 @@
       <uap:VisualElements
         DisplayName="Hosts File Editor CLI"
         Description="Hosts File Editor command line"
-        AppListEntry="none"
         BackgroundColor="transparent"
         Square150x150Logo="Assets\Square150x150Logo.png"
         Square44x44Logo="Assets\Square44x44Logo.png"/>

--- a/HostsFileEditor.WinUI/AppxManifest.xml
+++ b/HostsFileEditor.WinUI/AppxManifest.xml
@@ -40,8 +40,10 @@
         <uap:SplashScreen Image="Assets\Square150x150Logo.png"/>
       </uap:VisualElements>
     </Application>
-    <!-- Console launcher (issue #2): a hidden app entry whose appExecutionAlias puts `hfe` on PATH so
-         scripts can run `hfe -s Preset` etc. AppListEntry="none" keeps it off the Start menu. hfe.exe
+    <!-- Console launcher (issue #2): a second app entry whose appExecutionAlias puts `hfe` on PATH so
+         scripts can run `hfe -s Preset` etc. The entry is VISIBLE in the Start menu app list: hiding it
+         (AppListEntry="none") requires the account-level "HeadlessAppBypass" waiver, without which
+         Store package validation rejects the submission (hit on the 1.5.0/1.2.0 release). hfe.exe
          is console-subsystem, so cmd/PowerShell wait for it. -->
     <Application Id="Cli"
                  Executable="hfe.exe"
@@ -49,7 +51,6 @@
       <uap:VisualElements
         DisplayName="Hosts File Editor CLI"
         Description="Hosts File Editor command line"
-        AppListEntry="none"
         BackgroundColor="transparent"
         Square150x150Logo="Assets\Square150x150Logo.png"
         Square44x44Logo="Assets\Square44x44Logo.png"/>


### PR DESCRIPTION
Both 1.5.0/1.2.0 Store submissions failed **package acceptance validation**:

> The package file … specifies a headless app. You don't have permission to create a headless app. Please update AppListEntry="none" … and ensure you have the waiver "HeadlessAppBypass".

This was the one Store-policy risk the release review flagged on the hidden CLI entry. Fix: drop `AppListEntry="none"` from both manifests so the **"Hosts File Editor CLI"** entry is visible in the Start menu app list — the `hfe` execution alias is unchanged. Since the entry is now clickable, a bare `hfe` (no args) prints help and exits 0 instead of a usage error.

Rebuilt all four packages from this branch and resubmitted to the Store (see thread). Alternative considered: requesting the HeadlessAppBypass waiver from Store support — slower, can be pursued later to re-hide the entry if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)