### PR TITLE
#99 Guard against disable overwriting a different hosts.disabled (data loss)

### DIFF
--- a/HostsFileEditor.Core.Tests/HostsFileAdditionalTests.cs
+++ b/HostsFileEditor.Core.Tests/HostsFileAdditionalTests.cs
@@ -54,6 +54,46 @@ public class HostsFileAdditionalTests
         hf.Entries.First().IpAddress.ShouldBe("127.0.0.9");
     }
 
+    // Guard for #99: disabling must not silently overwrite a DIFFERENT existing hosts.disabled.
+    [TestMethod]
+    public void DisableWouldOverwriteDifferentFile_NoDisabledFile_False()
+    {
+        var live = Path.Combine(_tempDir, "hosts");
+        var disabled = Path.Combine(_tempDir, "hosts.disabled");
+        File.WriteAllText(live, "a");
+        HostsFile.DisableWouldOverwriteDifferentFile(live, disabled).ShouldBeFalse();
+    }
+
+    [TestMethod]
+    public void DisableWouldOverwriteDifferentFile_IdenticalContent_False()
+    {
+        var live = Path.Combine(_tempDir, "hosts");
+        var disabled = Path.Combine(_tempDir, "hosts.disabled");
+        File.WriteAllText(live, "127.0.0.1 localhost\n10.0.0.1 a");
+        File.WriteAllText(disabled, "127.0.0.1 localhost\n10.0.0.1 a");
+        HostsFile.DisableWouldOverwriteDifferentFile(live, disabled).ShouldBeFalse();
+    }
+
+    [TestMethod]
+    public void DisableWouldOverwriteDifferentFile_DifferentContent_True()
+    {
+        var live = Path.Combine(_tempDir, "hosts");
+        var disabled = Path.Combine(_tempDir, "hosts.disabled");
+        File.WriteAllText(live, "127.0.0.1 localhost");                 // fresh, foreign file
+        File.WriteAllText(disabled, "10.0.0.1 curated\n10.0.0.2 more"); // the copy we must not lose
+        HostsFile.DisableWouldOverwriteDifferentFile(live, disabled).ShouldBeTrue();
+    }
+
+    [TestMethod]
+    public void DisableWouldOverwriteDifferentFile_SameLengthDifferentBytes_True()
+    {
+        var live = Path.Combine(_tempDir, "hosts");
+        var disabled = Path.Combine(_tempDir, "hosts.disabled");
+        File.WriteAllText(live, "127.0.0.1 aaaaa");
+        File.WriteAllText(disabled, "127.0.0.1 bbbbb"); // same length, different content
+        HostsFile.DisableWouldOverwriteDifferentFile(live, disabled).ShouldBeTrue();
+    }
+
     [TestMethod]
     public void Import_SameFile_NoChange()
     {

--- a/HostsFileEditor.Core.Tests/HostsFileAdditionalTests.cs
+++ b/HostsFileEditor.Core.Tests/HostsFileAdditionalTests.cs
@@ -94,6 +94,28 @@ public class HostsFileAdditionalTests
         HostsFile.DisableWouldOverwriteDifferentFile(live, disabled).ShouldBeTrue();
     }
 
+    // Buffer-boundary coverage for the chunked FilesHaveSameContent compare (4096-byte reads):
+    // identical files at an exact multiple of the buffer, and two empty files, must both compare equal.
+    [TestMethod]
+    [DataRow(0)]      // both empty
+    [DataRow(4096)]   // exactly one buffer
+    [DataRow(8192)]   // exactly two buffers
+    [DataRow(8193)]   // two buffers + a short trailing read
+    public void DisableWouldOverwriteDifferentFile_IdenticalAtBufferBoundaries_False(int length)
+    {
+        var live = Path.Combine(_tempDir, "hosts");
+        var disabled = Path.Combine(_tempDir, "hosts.disabled");
+        var content = new byte[length];
+        for (var i = 0; i < length; i++)
+        {
+            content[i] = (byte)(i % 251); // deterministic, spans byte values
+        }
+
+        File.WriteAllBytes(live, content);
+        File.WriteAllBytes(disabled, content);
+        HostsFile.DisableWouldOverwriteDifferentFile(live, disabled).ShouldBeFalse();
+    }
+
     [TestMethod]
     public void Import_SameFile_NoChange()
     {

--- a/HostsFileEditor.Core.Tests/HostsFileAdditionalTests.cs
+++ b/HostsFileEditor.Core.Tests/HostsFileAdditionalTests.cs
@@ -116,6 +116,26 @@ public class HostsFileAdditionalTests
         HostsFile.DisableWouldOverwriteDifferentFile(live, disabled).ShouldBeFalse();
     }
 
+    // The difference is in the LAST byte, past the first 4096-byte buffer — so a compare that only
+    // checked the first chunk (and then returned "equal") would wrongly report no conflict and let the
+    // large differing hosts.disabled be overwritten. This exercises the multi-buffer mismatch path.
+    [TestMethod]
+    public void DisableWouldOverwriteDifferentFile_DifferInLastByteAcrossBuffers_True()
+    {
+        var live = Path.Combine(_tempDir, "hosts");
+        var disabled = Path.Combine(_tempDir, "hosts.disabled");
+        var content = new byte[8193]; // two full buffers + 1 byte
+        for (var i = 0; i < content.Length; i++)
+        {
+            content[i] = (byte)(i % 251);
+        }
+
+        File.WriteAllBytes(live, content);
+        content[^1] ^= 0xFF; // flip only the final byte
+        File.WriteAllBytes(disabled, content);
+        HostsFile.DisableWouldOverwriteDifferentFile(live, disabled).ShouldBeTrue();
+    }
+
     [TestMethod]
     public void Import_SameFile_NoChange()
     {

--- a/HostsFileEditor.Core/HostsFile.cs
+++ b/HostsFileEditor.Core/HostsFile.cs
@@ -168,6 +168,20 @@ public class HostsFile : INotifyPropertyChanged
 
     public void DisableHostsFile()
     {
+        // Guard against silent data loss: disabling renames the live hosts file over
+        // hosts.disabled (overwrite). If a hosts.disabled already exists whose contents differ
+        // — e.g. some other software recreated the live hosts file after a previous disable, so
+        // both files now exist — that Move would destroy the user's saved disabled configuration
+        // (and, with the load-time backup already overwritten, its only copy). Refuse and let the
+        // user resolve it, rather than losing data in a prompt-free scriptable command.
+        if (DisableWouldOverwriteDifferentFile(DefaultHostFilePath, DefaultDisabledHostFilePath))
+        {
+            throw new HostsFileConflictException(
+                $"A different disabled hosts file already exists ('{DefaultDisabledHostFilePath}'). " +
+                "Disabling now would overwrite it and lose that saved configuration. Enable the hosts " +
+                "file first to restore the disabled copy, or remove that file, then try again.");
+        }
+
         PrivilegedFileOperations.Current.Move(DefaultHostFilePath, DefaultDisabledHostFilePath);
         NativeMethods.FlushDns();
 
@@ -175,6 +189,61 @@ public class HostsFile : INotifyPropertyChanged
         // now-disabled file instead of recreating the enabled one. Runs only after a
         // successful Move (a declined UAC prompt throws before this and leaves state intact).
         _filePath = DefaultDisabledHostFilePath;
+    }
+
+    // Internal for tests. Would disabling (moving <paramref name="livePath"/> over
+    // <paramref name="disabledPath"/>) overwrite a DIFFERENT existing file, losing its contents?
+    // True only when both files exist and their contents differ — a missing disabled file or
+    // byte-identical contents is safe to overwrite. If the files exist but can't be read to
+    // compare, err on the side of caution and report a conflict rather than risk the overwrite.
+    internal static bool DisableWouldOverwriteDifferentFile(string livePath, string disabledPath)
+    {
+        if (!File.Exists(disabledPath) || !File.Exists(livePath))
+        {
+            return false;
+        }
+
+        try
+        {
+            return !FilesHaveSameContent(livePath, disabledPath);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return true;
+        }
+    }
+
+    private static bool FilesHaveSameContent(string pathA, string pathB)
+    {
+        if (new FileInfo(pathA).Length != new FileInfo(pathB).Length)
+        {
+            return false;
+        }
+
+        using var streamA = File.OpenRead(pathA);
+        using var streamB = File.OpenRead(pathB);
+        Span<byte> bufferA = stackalloc byte[4096];
+        Span<byte> bufferB = stackalloc byte[4096];
+
+        while (true)
+        {
+            var readA = streamA.ReadAtLeast(bufferA, bufferA.Length, throwOnEndOfStream: false);
+            var readB = streamB.ReadAtLeast(bufferB, bufferB.Length, throwOnEndOfStream: false);
+            if (readA != readB)
+            {
+                return false;
+            }
+
+            if (readA == 0)
+            {
+                return true;
+            }
+
+            if (!bufferA[..readA].SequenceEqual(bufferB[..readB]))
+            {
+                return false;
+            }
+        }
     }
 
     public void EnableHostsFile()

--- a/HostsFileEditor.Core/HostsFile.cs
+++ b/HostsFileEditor.Core/HostsFile.cs
@@ -178,8 +178,8 @@ public class HostsFile : INotifyPropertyChanged
         {
             throw new HostsFileConflictException(
                 $"A different disabled hosts file already exists ('{DefaultDisabledHostFilePath}'). " +
-                "Disabling now would overwrite it and lose that saved configuration. Enable the hosts " +
-                "file first to restore the disabled copy, or remove that file, then try again.");
+                "Disabling now would overwrite it and lose that saved configuration. Move or delete " +
+                "that file first, then try again.");
         }
 
         PrivilegedFileOperations.Current.Move(DefaultHostFilePath, DefaultDisabledHostFilePath);

--- a/HostsFileEditor.Core/HostsFileConflictException.cs
+++ b/HostsFileEditor.Core/HostsFileConflictException.cs
@@ -1,0 +1,25 @@
+namespace HostsFileEditor;
+
+/// <summary>
+/// Thrown when a hosts-file operation would destroy an existing saved configuration rather than
+/// silently overwriting it. Currently raised by <see cref="HostsFile.DisableHostsFile"/> when a
+/// <c>hosts.disabled</c> copy already exists whose contents differ from the live hosts file (e.g.
+/// the live file was recreated by other software after a previous disable). Callers surface the
+/// message and abort: the CLI prints it and exits non-zero, the GUIs show a dialog.
+/// </summary>
+public sealed class HostsFileConflictException : Exception
+{
+    public HostsFileConflictException()
+    {
+    }
+
+    public HostsFileConflictException(string message)
+        : base(message)
+    {
+    }
+
+    public HostsFileConflictException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/HostsFileEditor.WinForm/MainForm.cs
+++ b/HostsFileEditor.WinForm/MainForm.cs
@@ -601,6 +601,11 @@ internal sealed partial class MainForm : Form
         {
             // User declined the UAC prompt; the file was not renamed.
         }
+        catch (HostsFileConflictException ex)
+        {
+            // Disabling would overwrite a different existing hosts.disabled; refuse and explain.
+            MessageBox.Show(this, ex.Message, "Cannot Disable Hosts File", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+        }
         finally
         {
             // Sync the toggles from the ACTUAL file state (not the intended one) so a declined

--- a/HostsFileEditor.WinUI/MainWindow.xaml.cs
+++ b/HostsFileEditor.WinUI/MainWindow.xaml.cs
@@ -1672,6 +1672,13 @@ public sealed partial class MainWindow : Window, INotifyPropertyChanged
         {
             // User declined the UAC prompt; the file was not renamed.
         }
+        catch (HostsFileConflictException ex)
+        {
+            // Disabling would overwrite a different existing hosts.disabled — an intentional refusal,
+            // not an error. Show it as a neutral message (matches the classic edition's dedicated
+            // handler) rather than the generic "Error Changing Hosts File State" dialog.
+            await ShowInfoDialogAsync("Cannot Disable Hosts File", ex.Message);
+        }
         catch (Exception ex)
         {
             await ShowErrorDialogAsync("Error Changing Hosts File State", $"An error occurred while enabling or disabling the hosts file:\n\n{ex.Message}");


### PR DESCRIPTION
**Priority: P1 — data loss.** First of the v1.5.1/v1.2.1 release-review follow-ups.

## Problem (issue #99)
`DisableHostsFile` renames the live hosts file over `hosts.disabled` with overwrite. If both files exist — e.g. a VPN client / AV / OS repair recreates the live `hosts` after a previous `disable` — and they differ, that Move **silently destroyed the user's curated `hosts.disabled`** (and, with the load-time backup already overwritten, its only copy). Reachable prompt-free and scriptable via `hfe disable`, exit 0.

## Fix
`DisableHostsFile` now compares the live and disabled files first. When a **different** `hosts.disabled` already exists it throws `HostsFileConflictException` instead of overwriting:
- **CLI** → clean one-line message + exit 1 (top-level handler).
- **modern GUI** → already surfaced by its general `catch` (error dialog).
- **classic GUI** → added a matching `catch` + `MessageBox` (it previously caught only `ElevationCancelledException`).

Byte-identical content or a missing `hosts.disabled` still disables normally; an existing-but-unreadable file is treated conservatively as a conflict. `enable` is unchanged — it remains the only silently-overwriting direction (restoring the disabled copy is its job), matching the review's recommendation.

## Tests
New internal helper `DisableWouldOverwriteDifferentFile` unit-tested: missing disabled file, identical content, different content, same-length-different-bytes. Full Core suite green (178).

## Manual verification
- `hfe disable` with a differing `hosts.disabled` present → exit 1, message, **curated file preserved, live file untouched** ✔
- `hfe disable` with no `hosts.disabled` → normal disable, exit 0 ✔

**To validate:** the classic + modern GUI disable path when a stale differing `hosts.disabled` exists (should show the dialog / error, not disable); normal enable/disable round-trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)