### PR TITLE
#96 Fix ping-state consistency: stale results and clone desync

### DIFF
--- a/HostsFileEditor.Core.Tests/HostsEntryTests.cs
+++ b/HostsFileEditor.Core.Tests/HostsEntryTests.cs
@@ -1,4 +1,5 @@
 using HostsFileEditor.Utilities;
+using System.Reflection;
 
 namespace HostsFileEditor.Core.Tests;
 
@@ -260,6 +261,21 @@ public class HostsEntryTests
         clone.Comment.ShouldBe(entry.Comment);
         clone.Valid.ShouldBe(entry.Valid);
         clone.Enabled.ShouldBe(entry.Enabled);
+    }
+
+    // #96: the copy ctor copies the error dictionary, so it must also copy _pingFailed — otherwise a
+    // duplicate of a ping-failed row shows the error with PingFailed == false, and a later successful
+    // ping can never clear it (the "success && !_pingFailed" early-return skips the recovery report).
+    [TestMethod]
+    public void CloneConstructor_CopiesPingFailedState()
+    {
+        var entry = new HostsEntry("127.0.0.1 localhost");
+        var pingFailed = typeof(HostsEntry).GetField("_pingFailed", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        pingFailed.SetValue(entry, true); // simulate a prior failed ping
+
+        var clone = new HostsEntry(entry);
+
+        clone.PingFailed.ShouldBeTrue();
     }
 
     [TestMethod]

--- a/HostsFileEditor.Core/HostsEntry.cs
+++ b/HostsFileEditor.Core/HostsEntry.cs
@@ -362,6 +362,13 @@ public partial class HostsEntry : INotifyPropertyChanged, IDataErrorInfo
         _hostnamesValid = entry._hostnamesValid;
         _ipAddressValid = entry._ipAddressValid;
         _errors = entry._errors is null ? null : new Dictionary<string, string>(entry._errors);
+
+        // Copy the ping-failure flag alongside the error dictionary it corresponds to (issue #96):
+        // _errors is copied above and may hold the "Ping failed" message on the IP, so _pingFailed
+        // must match it. Copying only the error left the clone with _pingFailed == false, so a later
+        // successful ping hit the "success && !_pingFailed" early-return and never cleared the stale
+        // error — it stuck until the IP was edited.
+        _pingFailed = entry._pingFailed;
     }
 
     public event PropertyChangedEventHandler? PropertyChanged;
@@ -804,6 +811,15 @@ public partial class HostsEntry : INotifyPropertyChanged, IDataErrorInfo
 
         void Report()
         {
+            // The IP may have been edited while this ping was in flight; if so, this result is for
+            // the OLD address and must not touch the current one (issue #96). Without this, a stale
+            // timeout for a since-replaced address marks the NEW (possibly reachable) address as
+            // ping-failed, and it never re-pings until the next manual ping or reload.
+            if (!string.Equals(address, _ipAddress, StringComparison.Ordinal))
+            {
+                return;
+            }
+
             if (status == IPStatus.Success)
             {
                 // Recovered: clear the ping-failure state. Only a ping failure could have set an IP


### PR DESCRIPTION
**Priority: correctness (non-blocker).** v1.5.1/v1.2.1 release-review follow-up. Two related ping-state defects in `HostsEntry` (from #9/#89).

## 1. Stale ping result marks the wrong (current) IP failed
With auto-ping on: entry has unreachable IP A (ping in flight, ~5s timeout). User edits the IP to reachable B — `ValidateIpAddress` clears `PingFailed` and pings B (succeeds fast, early-returns without reporting). A's timed-out ping then lands and marks the entry — **now showing B** — as ping-failed, and nothing re-pings it until reload/Ping-All/another edit.

**Fix:** `PingAsync` already receives the pinged `address`; `Report()` now drops the result when `address != _ipAddress` (the IP changed under it).

## 2. Duplicate of a ping-failed row desyncs and sticks
The copy constructor copied `_errors` (which can hold the "Ping failed" message on the IP) but **not** `_pingFailed`. A duplicated row showed the error with `PingFailed == false`, and a later successful ping hit the `success && !_pingFailed` early-return, so the stale error **never cleared** (until the IP was edited).

**Fix:** the clone now copies `_pingFailed` to match the copied `_errors`, keeping the two consistent (so recovery reports fire).

## Tests
Copy ctor carries `_pingFailed`. Full Core suite green (175). (Part 1 is a timing path with no deterministic unit repro — see below.)

## Validation note
**To validate manually (auto-ping on):** (1) add an entry with an unreachable IP, watch it flag failed, then edit it to a reachable IP → it should NOT stay/re-flag failed once the old ping's timeout lands. (2) Duplicate a ping-failed row → the copy shows the same state and, if its host becomes reachable and it's re-pinged, the failure clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)