### PR TITLE
#98 CLI: report ambiguous preset stems instead of picking by FS order

### DIFF
--- a/HostsFileEditor.Core.Tests/HostsCliTests.cs
+++ b/HostsFileEditor.Core.Tests/HostsCliTests.cs
@@ -138,6 +138,18 @@ public class HostsCliTests
             () => HostsCli.ResolvePreset("Nope", out _, out _).ShouldBe(HostsCli.PresetResolution.NotFound));
     }
 
+    [TestMethod]
+    public void ResolvePreset_StemMatchIsCaseInsensitive()
+    {
+        WithTempArchives(
+            dir => File.WriteAllText(Path.Combine(dir, "Work.txt"), "a"),
+            () =>
+            {
+                HostsCli.ResolvePreset("work", out var archive, out _).ShouldBe(HostsCli.PresetResolution.Found);
+                archive!.FileName.ShouldBe("Work.txt");
+            });
+    }
+
     private static void WithTempArchives(Action<string> populate, Action body)
     {
         var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());

--- a/HostsFileEditor.Core.Tests/HostsCliTests.cs
+++ b/HostsFileEditor.Core.Tests/HostsCliTests.cs
@@ -81,4 +81,79 @@ public class HostsCliTests
         code.ShouldBe(HostsCli.ExitUsage);
         error.ToString().ShouldContain("Unknown");
     }
+
+    // #98: an extension-lenient stem that matches more than one archive must be reported as
+    // ambiguous, not silently resolved by file-system enumeration order.
+    [TestMethod]
+    public void ResolvePreset_AmbiguousStem_ReportsAmbiguityWithAllNames()
+    {
+        WithTempArchives(
+            dir =>
+            {
+                File.WriteAllText(Path.Combine(dir, "Foo.txt"), "a");
+                File.WriteAllText(Path.Combine(dir, "Foo.bak"), "b");
+            },
+            () =>
+            {
+                var result = HostsCli.ResolvePreset("Foo", out var archive, out var names);
+                result.ShouldBe(HostsCli.PresetResolution.Ambiguous);
+                archive.ShouldBeNull();
+                names.ShouldBe(["Foo.bak", "Foo.txt"]); // ordered by FileNameComparer, both listed
+            });
+    }
+
+    [TestMethod]
+    public void ResolvePreset_ExactNameBeatsStem()
+    {
+        WithTempArchives(
+            dir =>
+            {
+                File.WriteAllText(Path.Combine(dir, "Foo"), "a");     // exact
+                File.WriteAllText(Path.Combine(dir, "Foo.txt"), "b"); // stem match
+            },
+            () =>
+            {
+                HostsCli.ResolvePreset("Foo", out var archive, out _).ShouldBe(HostsCli.PresetResolution.Found);
+                archive!.FileName.ShouldBe("Foo");
+            });
+    }
+
+    [TestMethod]
+    public void ResolvePreset_SingleStem_ResolvesWithExtension()
+    {
+        WithTempArchives(
+            dir => File.WriteAllText(Path.Combine(dir, "Bar.txt"), "a"),
+            () =>
+            {
+                HostsCli.ResolvePreset(" Bar ", out var archive, out _).ShouldBe(HostsCli.PresetResolution.Found);
+                archive!.FileName.ShouldBe("Bar.txt");
+            });
+    }
+
+    [TestMethod]
+    public void ResolvePreset_NoMatch_NotFound()
+    {
+        WithTempArchives(
+            dir => File.WriteAllText(Path.Combine(dir, "Bar.txt"), "a"),
+            () => HostsCli.ResolvePreset("Nope", out _, out _).ShouldBe(HostsCli.PresetResolution.NotFound));
+    }
+
+    private static void WithTempArchives(Action<string> populate, Action body)
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(dir);
+        HostsArchiveList.TestArchiveDirectoryOverride = dir;
+        try
+        {
+            populate(dir);
+            HostsArchiveList.Instance.Refresh();
+            body();
+        }
+        finally
+        {
+            HostsArchiveList.TestArchiveDirectoryOverride = null;
+            HostsArchiveList.Instance.Refresh();
+            Directory.Delete(dir, true);
+        }
+    }
 }

--- a/HostsFileEditor.Core/CommandLine/HostsCli.cs
+++ b/HostsFileEditor.Core/CommandLine/HostsCli.cs
@@ -191,7 +191,7 @@ public static class HostsCli
                 return ExitError;
 
             case PresetResolution.NotFound:
-                error.WriteLine($"Preset '{name}' not found. Run 'list' to see available presets.");
+                error.WriteLine($"Preset '{name.Trim()}' not found. Run 'list' to see available presets.");
                 return ExitError;
         }
 

--- a/HostsFileEditor.Core/CommandLine/HostsCli.cs
+++ b/HostsFileEditor.Core/CommandLine/HostsCli.cs
@@ -182,15 +182,22 @@ public static class HostsCli
 
     private static int ApplyPreset(string name, TextWriter output, TextWriter error)
     {
-        var archive = FindPreset(name);
-        if (archive is null)
+        switch (ResolvePreset(name, out var archive, out var ambiguousNames))
         {
-            error.WriteLine($"Preset '{name}' not found. Run 'list' to see available presets.");
-            return ExitError;
+            case PresetResolution.Ambiguous:
+                error.WriteLine(
+                    $"Preset '{name.Trim()}' is ambiguous - it matches {string.Join(", ", ambiguousNames)}. " +
+                    "Use the full preset name (with its extension).");
+                return ExitError;
+
+            case PresetResolution.NotFound:
+                error.WriteLine($"Preset '{name}' not found. Run 'list' to see available presets.");
+                return ExitError;
         }
 
+        // The switch returned for Ambiguous/NotFound, so Found guarantees a non-null archive here.
         PrivilegedFileOperations.UseElevationHelper();
-        HostsFile.Instance.Import(archive.FilePath);
+        HostsFile.Instance.Import(archive!.FilePath);
         HostsFile.Instance.Save();
         output.WriteLine($"Applied preset '{archive.FileName}' to the hosts file.");
         NoteIfDisabled(output);
@@ -272,15 +279,53 @@ public static class HostsCli
         return ExitSuccess;
     }
 
-    private static HostsArchive? FindPreset(string name)
+    internal enum PresetResolution
     {
-        // Tolerate surrounding whitespace from a quoted argument, then match by exact file name
-        // (HostsArchiveList.FindByName) and finally ignoring the extension so `MyHosts1` resolves
-        // `MyHosts1.txt` too.
+        Found,
+        NotFound,
+        Ambiguous,
+    }
+
+    // Resolves a preset name to a single archive. Tolerates surrounding whitespace from a quoted
+    // argument, then matches by exact file name (HostsArchiveList.FindByName) and finally, only if
+    // that fails, ignoring the extension so `MyHosts1` resolves `MyHosts1.txt`. When the
+    // extension-lenient match is ambiguous (e.g. both `Foo.txt` and `Foo.bak` exist) it returns
+    // Ambiguous rather than silently picking one by file-system enumeration order (#98) — silently
+    // applying the wrong preset over the live hosts file is exactly the risk to avoid. Internal for
+    // tests.
+    internal static PresetResolution ResolvePreset(string name, out HostsArchive? archive, out IReadOnlyList<string> ambiguousNames)
+    {
+        archive = null;
+        ambiguousNames = [];
+
         var trimmed = name.Trim();
         var presets = HostsArchiveList.Instance;
-        return presets.FindByName(trimmed)
-            ?? presets.FirstOrDefault(a => string.Equals(Path.GetFileNameWithoutExtension(a.FileName), trimmed, StringComparison.OrdinalIgnoreCase));
+
+        // Exact file-name match wins outright, so `Foo.txt` deterministically beats a `Foo` stem.
+        archive = presets.FindByName(trimmed);
+        if (archive is not null)
+        {
+            return PresetResolution.Found;
+        }
+
+        var stemMatches = presets
+            .Where(a => string.Equals(Path.GetFileNameWithoutExtension(a.FileName), trimmed, StringComparison.OrdinalIgnoreCase))
+            .OrderBy(a => a, HostsArchive.FileNameComparer)
+            .ToList();
+
+        if (stemMatches.Count > 1)
+        {
+            ambiguousNames = [.. stemMatches.Select(a => a.FileName)];
+            return PresetResolution.Ambiguous;
+        }
+
+        if (stemMatches.Count == 1)
+        {
+            archive = stemMatches[0];
+            return PresetResolution.Found;
+        }
+
+        return PresetResolution.NotFound;
     }
 
     private static bool TryMapVerb(string token, out CliVerb verb)


### PR DESCRIPTION
**Priority: correctness (non-blocker).** v1.5.1/v1.2.1 release-review follow-up.

## Problem (issue #98)
`FindPreset`'s extension-lenient fallback (`Foo` resolving `Foo.txt`) used `FirstOrDefault` over `HostsArchiveList.Instance`, whose order is `Directory.GetFiles` order — which the BCL explicitly does not guarantee. With two archives sharing a stem (`Foo.txt` + `Foo.bak`), `hfe apply Foo` silently applied whichever the file system enumerated first, and the same script could pick a different preset on a different machine — silently applying the **wrong hosts content**.

## Fix
Replaced `FindPreset` with `ResolvePreset` → `Found` / `NotFound` / `Ambiguous`:
- An **exact** file-name match still wins outright (`Foo.txt` beats a `Foo` stem).
- The extension-lenient fallback now collects **all** stem matches; more than one → `Ambiguous`.

`apply` on an ambiguous stem now prints e.g. `Preset 'Foo' is ambiguous - it matches Foo.bak, Foo.txt. Use the full preset name (with its extension).` and exits 1, instead of guessing. (`list` already ordered by `FileNameComparer`; the ambiguity message uses the same order.)

## Tests
`ResolvePreset`: ambiguous stem lists all names in stable order; exact beats stem; single stem resolves with extension; no match → NotFound. Full Core suite green (178).

## Validation note
Edge case needing two same-stem archives. **To validate:** save two archives named e.g. `Work.txt` and `Work.bak`, then `hfe apply Work` → ambiguity message + exit 1; `hfe apply Work.txt` → applies deterministically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)