### PR TITLE
#107 Classic: carry user settings forward across version bumps (Settings.Upgrade)

### DIFF
--- a/HostsFileEditor.WinForm/MainForm.cs
+++ b/HostsFileEditor.WinForm/MainForm.cs
@@ -1587,8 +1587,19 @@ internal sealed partial class MainForm : Form
         {
             settings = Settings.Default;
 
-            // The first property access loads user.config; a corrupt file throws here. Recover
-            // and start with defaults rather than failing to launch (issue #37).
+            // user.config is stored in a per-app-version folder, so on the first run after a version
+            // bump every saved setting would otherwise reset to defaults (window bounds, auto-ping,
+            // the configurable global hotkey, etc.). Upgrade() carries the previous version's values
+            // forward; a persisted flag makes it a one-time migration, and saving it immediately means
+            // a crash before exit can't cause a re-upgrade. This first property access also loads
+            // user.config, so a corrupt file throws here and is recovered below (issue #37).
+            if (!settings.SettingsUpgraded)
+            {
+                settings.Upgrade();
+                settings.SettingsUpgraded = true;
+                settings.Save();
+            }
+
             _ = settings.AutoPingIPAddresses;
         }
         catch (ConfigurationErrorsException ex)

--- a/HostsFileEditor.WinForm/Properties/Settings.Designer.cs
+++ b/HostsFileEditor.WinForm/Properties/Settings.Designer.cs
@@ -82,6 +82,18 @@ namespace HostsFileEditor.Properties {
                 this["AutoPingIPAddresses"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool SettingsUpgraded {
+            get {
+                return ((bool)(this["SettingsUpgraded"]));
+            }
+            set {
+                this["SettingsUpgraded"] = value;
+            }
+        }
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]

--- a/HostsFileEditor.WinForm/Properties/Settings.settings
+++ b/HostsFileEditor.WinForm/Properties/Settings.settings
@@ -17,6 +17,9 @@
     <Setting Name="AutoPingIPAddresses" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="SettingsUpgraded" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
     <Setting Name="WindowState" Type="System.Windows.Forms.FormWindowState" Scope="User">
       <Value Profile="(Default)">Normal</Value>
     </Setting>

--- a/HostsFileEditor.WinForm/app.config
+++ b/HostsFileEditor.WinForm/app.config
@@ -40,6 +40,9 @@ with HostsFileEditor. If not, see http://www.gnu.org/licenses/.
       <setting name="AutoPingIPAddresses" serializeAs="String">
         <value>False</value>
       </setting>
+      <setting name="SettingsUpgraded" serializeAs="String">
+        <value>False</value>
+      </setting>
       <setting name="WindowState" serializeAs="String">
         <value>Normal</value>
       </setting>


### PR DESCRIPTION
**Priority: correctness (non-blocker), pre-existing.** v1.5.1/v1.2.1 release-review follow-up.

## Problem (issue #107)
The classic edition's `user.config` is scoped by AssemblyVersion, and `LoadSettings` never called `Settings.Default.Upgrade()`. So **every version bump silently reset all user settings** — window size/position, splitter width, ArchiveVisible, AutoPingIPAddresses, RemoveDefaultText — and now the new `GlobalShowHideHotkey` (#91), whose *only* configuration surface is that version-scoped file (so any customization is discarded at the next bump).

## Fix
Add a user-scoped `SettingsUpgraded` flag (default `false`). On load, if not yet upgraded: `Settings.Upgrade()` (carries the previous version's values forward), set the flag, and `Save()` immediately (so a crash before exit can't trigger a re-upgrade). It runs inside the existing corrupt-config guard, so a bad `user.config` still recovers to defaults (issue #37).

`1.4.1 → 1.5.0` is already lost (no flag existed then), but this makes `1.5.0 → 1.5.1` and every future bump preserve settings.

## Tests
No unit coverage (WinForms `ApplicationSettingsBase`; the `Upgrade()`/version-folder mechanism is framework-provided and not unit-testable without a real prior-version config). Classic builds clean.

## Validation note
**To validate:** with 1.5.0 installed, change some settings (window size, enable auto-ping, set a custom hotkey) and exit. Install a build with a bumped version (e.g. 1.5.1) — the settings should carry over instead of resetting. (First run of *this* build after 1.5.0 won't recover the already-lost 1.4.1→1.5.0 values, but establishes the flag so future bumps are preserved.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)