### PR TITLE
#97 Don't ping discarded duplicates during MergeLines

### DIFF
--- a/HostsFileEditor.Core.Tests/HostsEntryListTests.cs
+++ b/HostsFileEditor.Core.Tests/HostsEntryListTests.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Reflection;
 using HostsFileEditor.Utilities;
 
 namespace HostsFileEditor.Core.Tests;
@@ -12,6 +13,29 @@ public class HostsEntryListTests
         var lines = new[] { "127.0.0.1 localhost", "::1 localhost" };
         var list = new HostsEntryList(lines, filterDefault: false);
         list.Count.ShouldBe(lines.Length);
+    }
+
+    // #97: SuspendAutoPing must nest (ref-counted) and fully restore, so a merge can't leave the
+    // parse-time auto-ping permanently suppressed.
+    [TestMethod]
+    public void SuspendAutoPing_NestsAndRestores()
+    {
+        var field = typeof(HostsEntry).GetField("_autoPingSuspended", BindingFlags.NonPublic | BindingFlags.Static)!;
+        int Count() => (int)field.GetValue(null)!;
+
+        var start = Count();
+        using (HostsEntry.SuspendAutoPing())
+        {
+            Count().ShouldBe(start + 1);
+            using (HostsEntry.SuspendAutoPing())
+            {
+                Count().ShouldBe(start + 2);
+            }
+
+            Count().ShouldBe(start + 1);
+        }
+
+        Count().ShouldBe(start);
     }
 
     [TestMethod]

--- a/HostsFileEditor.Core/HostsEntry.cs
+++ b/HostsFileEditor.Core/HostsEntry.cs
@@ -113,7 +113,7 @@ public partial class HostsEntry : INotifyPropertyChanged, IDataErrorInfo
                 // IPAddress.TryParse, which would double the per-entry IP-parse cost on the 400K-line
                 // hot load path. The IpAddress setter (edit path) still validates via ValidateIpAddress.
                 _ipAddressValid = true;
-                if (AutoPingIPAddress)
+                if (AutoPingIPAddress && !AutoPingSuspended)
                 {
                     Ping();
                 }
@@ -367,6 +367,40 @@ public partial class HostsEntry : INotifyPropertyChanged, IDataErrorInfo
     public event PropertyChangedEventHandler? PropertyChanged;
 
     public static bool AutoPingIPAddress { get; set; }
+
+    private static int _autoPingSuspended;
+
+    /// <summary>
+    /// Suspends the parse-time auto-ping (the ping fired from the constructor when
+    /// <see cref="AutoPingIPAddress"/> is on) for the lifetime of the returned scope. Used when
+    /// entries are constructed only to be inspected and possibly discarded — e.g.
+    /// <see cref="HostsEntryList.MergeLines"/> builds one entry per incoming line to compute its dedup
+    /// identity, and without this every line of the merged file (including duplicates never added)
+    /// launched a live ping (issue #97). Callers ping the entries they actually keep afterwards.
+    /// </summary>
+    internal static IDisposable SuspendAutoPing()
+    {
+        Interlocked.Increment(ref _autoPingSuspended);
+        return new AutoPingSuspension();
+    }
+
+    private static bool AutoPingSuspended => Volatile.Read(ref _autoPingSuspended) > 0;
+
+    private sealed class AutoPingSuspension : IDisposable
+    {
+        private bool _disposed;
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            Interlocked.Decrement(ref _autoPingSuspended);
+        }
+    }
 
     /// <summary>
     /// UI-thread synchronization context used to marshal ping-failure notifications when the ping

--- a/HostsFileEditor.Core/HostsEntry.cs
+++ b/HostsFileEditor.Core/HostsEntry.cs
@@ -368,23 +368,30 @@ public partial class HostsEntry : INotifyPropertyChanged, IDataErrorInfo
 
     public static bool AutoPingIPAddress { get; set; }
 
+    // Thread-scoped: the suppression only needs to cover entries constructed on the SAME thread that
+    // opened the scope (MergeLines builds its probe entries inline on one thread). [ThreadStatic]
+    // keeps a concurrent construction on another thread — a background load, say — from having its
+    // legitimate auto-ping silently swallowed. Because it's thread-local, plain ++/-- suffice (no
+    // cross-thread contention). The scope must be disposed on the thread that created it.
+    [ThreadStatic]
     private static int _autoPingSuspended;
 
     /// <summary>
     /// Suspends the parse-time auto-ping (the ping fired from the constructor when
-    /// <see cref="AutoPingIPAddress"/> is on) for the lifetime of the returned scope. Used when
-    /// entries are constructed only to be inspected and possibly discarded — e.g.
+    /// <see cref="AutoPingIPAddress"/> is on) for the lifetime of the returned scope, on the CURRENT
+    /// thread. Used when entries are constructed only to be inspected and possibly discarded — e.g.
     /// <see cref="HostsEntryList.MergeLines"/> builds one entry per incoming line to compute its dedup
     /// identity, and without this every line of the merged file (including duplicates never added)
     /// launched a live ping (issue #97). Callers ping the entries they actually keep afterwards.
+    /// Dispose on the same thread that created the scope.
     /// </summary>
     internal static IDisposable SuspendAutoPing()
     {
-        Interlocked.Increment(ref _autoPingSuspended);
+        _autoPingSuspended++;
         return new AutoPingSuspension();
     }
 
-    private static bool AutoPingSuspended => Volatile.Read(ref _autoPingSuspended) > 0;
+    private static bool AutoPingSuspended => _autoPingSuspended > 0;
 
     private sealed class AutoPingSuspension : IDisposable
     {
@@ -398,7 +405,7 @@ public partial class HostsEntry : INotifyPropertyChanged, IDataErrorInfo
             }
 
             _disposed = true;
-            Interlocked.Decrement(ref _autoPingSuspended);
+            _autoPingSuspended--;
         }
     }
 

--- a/HostsFileEditor.Core/HostsEntryList.cs
+++ b/HostsFileEditor.Core/HostsEntryList.cs
@@ -94,21 +94,28 @@ public class HostsEntryList : BindingList<HostsEntry>
         }
 
         var toAdd = new List<HostsEntry>();
-        foreach (var line in lines)
+
+        // Each incoming line is parsed only to compute its identity; most may be duplicates that are
+        // never added. Suspend the parse-time auto-ping so we don't fire a live ping per probed line
+        // (issue #97) — the entries actually kept are pinged once, after the append, below.
+        using (HostsEntry.SuspendAutoPing())
         {
-            var entry = new HostsEntry(line);
-
-            // Merge only real host entries; skip comment-only lines and blanks from the incoming file.
-            if (!entry.Valid)
+            foreach (var line in lines)
             {
-                continue;
-            }
+                var entry = new HostsEntry(line);
 
-            // HashSet.Add is false when the identity is already present (existing OR earlier in this
-            // same merge), so the first occurrence wins and later duplicates are dropped.
-            if (identities.Add(IdentityOf(entry)))
-            {
-                toAdd.Add(entry);
+                // Merge only real host entries; skip comment-only lines and blanks from the incoming file.
+                if (!entry.Valid)
+                {
+                    continue;
+                }
+
+                // HashSet.Add is false when the identity is already present (existing OR earlier in this
+                // same merge), so the first occurrence wins and later duplicates are dropped.
+                if (identities.Add(IdentityOf(entry)))
+                {
+                    toAdd.Add(entry);
+                }
             }
         }
 
@@ -116,6 +123,16 @@ public class HostsEntryList : BindingList<HostsEntry>
         // ClearHistory: an append doesn't invalidate existing entries' indices, so prior undo actions
         // stay valid, and the merge itself is a single undoable step (Ctrl+Z removes the added block).
         InsertRange(toAdd);
+
+        // Auto-ping the entries actually kept (parse-time ping was suspended above), matching the
+        // pre-fix behavior for added entries without the storm of pings for discarded duplicates.
+        if (HostsEntry.AutoPingIPAddress)
+        {
+            foreach (var entry in toAdd)
+            {
+                entry.Ping();
+            }
+        }
 
         return toAdd.Count;
 


### PR DESCRIPTION
**Priority: perf/noise (non-blocker).** v1.5.1/v1.2.1 release-review follow-up.

## Problem (issue #97)
`MergeLines` constructs one `HostsEntry` per incoming line to compute its dedup identity. With auto-ping on, the constructor's parse-time ping fired a **live ICMP ping for every incoming line** — including duplicates and lines never added. Merging a large blocklist (e.g. 400K lines) with "Ping IPs" on launched one fire-and-forget ping per line, mostly for throwaway objects: the "Pinging…" indicator wedged for the whole storm, plus thread-pool/ICMP-handle pressure far beyond what the merge actually added.

## Fix
New `HostsEntry.SuspendAutoPing()` — a ref-counted scope that suppresses the constructor's auto-ping. `MergeLines` builds its probe entries inside the scope (no pings), then pings **only the entries it actually keeps**, after the append. So added entries still auto-ping (unchanged behavior); discarded duplicates don't.

This is a distinct mechanism from #103's `SuspendPingReporting` (that drops ping *results* during a background mutate; this stops the ping from *starting* during identity probing) — they don't overlap.

## Tests
`SuspendAutoPing` nests and fully restores (deterministic). Dedup/count behavior is unchanged and already covered by existing `MergeLines_*` tests. (An auto-ping-on merge test was deliberately omitted — it would fire real network pings, which the suite forbids and which pollute shared ping state.)

## Validation note
**To validate (modern or classic):** enable auto-ping, then Merge a large hosts file with many duplicates — the ping indicator should reflect only the newly-added entries, not spin for the whole incoming file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)