### PR TITLE
#102 Classic: don't block the UI thread when a Jump List preset arrives mid-load

### DIFF
--- a/HostsFileEditor.WinForm/MainForm.cs
+++ b/HostsFileEditor.WinForm/MainForm.cs
@@ -52,6 +52,20 @@ internal sealed partial class MainForm : Form
     private bool _loadFailed;
 
     /// <summary>
+    /// Set once the initial off-thread hosts-file load has completed successfully and the grid is
+    /// bound. Until then, commands that touch <c>HostsFile.Instance</c> must not run — see
+    /// <see cref="RequestOpenArchive"/>, which defers a Jump List activation that arrives mid-load
+    /// rather than blocking the UI thread on the in-progress <c>Lazy</c> parse (issue #102).
+    /// </summary>
+    private bool _loaded;
+
+    /// <summary>
+    /// A Jump List preset whose activation arrived while the initial load was still running; opened by
+    /// <see cref="OnFomLoad"/> once the load completes. See <see cref="RequestOpenArchive"/>.
+    /// </summary>
+    private string? _pendingOpenArchive;
+
+    /// <summary>
     /// Identifier for the global show/hide hot key (issue #35). Any per-process-unique value; chosen
     /// away from 0 to avoid clashing with a default-0 registration elsewhere.
     /// </summary>
@@ -276,6 +290,18 @@ internal sealed partial class MainForm : Form
     {
         if (string.IsNullOrEmpty(archivePath) || !File.Exists(archivePath))
         {
+            return;
+        }
+
+        // The initial hosts-file load parses off the UI thread. Until it finishes, this method must
+        // not run: ConfirmDiscardUnsavedChanges reads HostsFile.Instance.IsModified, which would block
+        // the UI thread on the in-progress Lazy parse (a "Not Responding" freeze on a large file) — or,
+        // after a failed load, rethrow the cached Lazy exception out of this BeginInvoke'd callback into
+        // Application.ThreadException. Defer to _pendingOpenArchive; OnFomLoad opens it once loaded
+        // (issue #102). The command surfaces are disabled during the load for the same reason.
+        if (!_loaded)
+        {
+            _pendingOpenArchive = archivePath;
             return;
         }
 
@@ -879,6 +905,9 @@ internal sealed partial class MainForm : Form
         TaskbarJumpList.Refresh();
         HostsArchiveList.Instance.ListChanged += (s1, e1) => TaskbarJumpList.Refresh();
 
+        // The load succeeded and the grid is bound: RequestOpenArchive may now touch Instance safely.
+        _loaded = true;
+
         // If launched fresh from a Jump List entry (--open-archive "<path>"), open that preset now
         // that the hosts file is loaded. The already-running case is handled in WndProc (a second
         // instance forwards the path via TaskbarJumpList). RequestOpenArchive warns on unsaved changes.
@@ -886,6 +915,14 @@ internal sealed partial class MainForm : Form
         if (openArchivePath is not null)
         {
             RequestOpenArchive(openArchivePath);
+        }
+
+        // A Jump List activation forwarded by WndProc DURING the load was deferred (issue #102); open
+        // it now. (Left null by the fresh-launch path above, which opens directly.)
+        if (_pendingOpenArchive is { } deferredArchive)
+        {
+            _pendingOpenArchive = null;
+            RequestOpenArchive(deferredArchive);
         }
 
         // HACK: Make sure a newly added row gets committed after

--- a/HostsFileEditor.WinForm/MainForm.cs
+++ b/HostsFileEditor.WinForm/MainForm.cs
@@ -918,8 +918,10 @@ internal sealed partial class MainForm : Form
         }
 
         // A Jump List activation forwarded by WndProc DURING the load was deferred (issue #102); open
-        // it now. (Left null by the fresh-launch path above, which opens directly.)
-        if (_pendingOpenArchive is { } deferredArchive)
+        // it now — unless a fresh-launch --open-archive already opened one above. Skipping it then
+        // avoids a double import plus a spurious "unsaved changes?" prompt (the first import marks the
+        // file modified); the fresh-launch preset takes precedence for this launch.
+        if (openArchivePath is null && _pendingOpenArchive is { } deferredArchive)
         {
             _pendingOpenArchive = null;
             RequestOpenArchive(deferredArchive);


### PR DESCRIPTION
**Priority: UI bug (non-blocker).** v1.5.1/v1.2.1 release-review follow-up (Jump List #10 × async-load gating).

## Problem (issue #102)
`WndProc` forwards a second instance's Jump List preset via `BeginInvoke(() => RequestOpenArchive(...))`. If it arrived while the initial off-thread parse was still running, `RequestOpenArchive` → `ConfirmDiscardUnsavedChanges` → `HostsFile.Instance.IsModified` **forced the `Lazy<HostsFile>` on the UI thread** — a "Not Responding" freeze until the parse finished (seconds-to-minutes on a 400K-line file). After a *failed* load it rethrew the cached `Lazy` exception out of the callback into `Application.ThreadException` (a second error box atop the real one). The `WM_HOTKEY` branch in the same `WndProc` was already safe (`ToggleShowHide` touches no `Instance`); only the Jump List branch escaped the load gating.

## Fix
Add a `_loaded` flag, set after the successful load once the grid is bound. `RequestOpenArchive` defers to `_pendingOpenArchive` while `!_loaded` (never touching `Instance`), and `OnFomLoad` opens any deferred archive after the load completes — mirroring how the command surfaces stay disabled during the load. The fresh-launch path is unaffected (it already runs post-load). On a failed load `_loaded` stays false, so a mid-exit forward defers instead of rethrowing.

## Validation note
UI timing behavior, no unit repro. **To validate (classic, packaged so the Jump List is active), ideally on a large hosts file:** with the app open and mid-load (or launch it against a big `HFE_HOSTS_PATH`), click a taskbar Jump List preset during the load — the window should stay responsive and open the preset once loaded, instead of freezing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)