### PR TITLE
#104 Modern: paste appends at end while a display sort is active

### DIFF
--- a/HostsFileEditor.WinUI/MainWindow.xaml.cs
+++ b/HostsFileEditor.WinUI/MainWindow.xaml.cs
@@ -1600,18 +1600,28 @@ public sealed partial class MainWindow : Window, INotifyPropertyChanged
             // row as SelectedItem) but at the BOTTOM above it (logical select-all leaves it null) —
             // opposite file ends across an invisible 20K boundary. Rebind in bulk (not the per-item
             // RefreshEntries diff, which is O(n^2) for pasting a whole file).
-            var current = EntriesList.SelectedItem as HostsEntry;
-            if (current is null && _logicalSelectAll)
+            //
+            // While a display sort is active, the selected row's FILE position is unpredictable, so
+            // "insert before the selection" would drop the pasted rows at an arbitrary spot that then
+            // re-sorts elsewhere in the view (issue #104). Anchor on null → Core appends at the end of
+            // the file, a defined and predictable position — Insert/Move are disabled entirely while
+            // sorted for the same "no defined position" reason; Paste stays usable but appends.
+            HostsEntry? current = null;
+            if (!IsSortActive)
             {
-                current = Entries.FirstOrDefault();
-            }
-
-            if (current is null && _selectedEntries.Count > 0)
-            {
-                var (_, minIndex, _) = ScanSelectedRange();
-                if (minIndex >= 0)
+                current = EntriesList.SelectedItem as HostsEntry;
+                if (current is null && _logicalSelectAll)
                 {
-                    current = Entries[minIndex];
+                    current = Entries.FirstOrDefault();
+                }
+
+                if (current is null && _selectedEntries.Count > 0)
+                {
+                    var (_, minIndex, _) = ScanSelectedRange();
+                    if (minIndex >= 0)
+                    {
+                        current = Entries[minIndex];
+                    }
                 }
             }
 


### PR DESCRIPTION
**Priority: UX consistency (low).** v1.5.1/v1.2.1 release-review follow-up (sort #81).

## Problem (issue #104)
Insert Above/Below and Move are disabled while a display sort is active because "above/below a display row" has no defined *file* position. But **Paste** wasn't gated: it anchored on the first selected display row and inserted before that entry's invisible file position, so with a sort active the pasted rows landed at an unpredictable spot and then re-sorted elsewhere in the view — the same operation class as the gated Insert.

## Fix
While `IsSortActive`, Paste anchors on `null` so Core **appends at the end of the file** — a defined, predictable position — keeping Paste usable rather than disabling it. Unsorted paste is unchanged (insert before the first selected row / append with no selection).

**Design choice:** I kept Paste functional (append-at-end) rather than disabling it like Insert/Move, since pasting into a sorted view is still useful and end-of-file is unambiguous. If you'd rather it be *disabled* while sorted for strict consistency with Insert/Move, that's a one-line change — say the word. Duplicate is left as-is (a copy sorts adjacent to its original via the stable tie-break, so it's already predictable).

## Validation note
**To validate (modern):** apply a sort, copy some rows, select a row mid-view, and Paste → the pasted rows should appear at the end of the underlying file (visible at the end when you clear the sort), not at an arbitrary sorted position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)