### PR TITLE
#106 Classic: Jump List launches via a version-independent alias when packaged

### DIFF
--- a/HostsFileEditor.Core/Win32/NativeMethods.cs
+++ b/HostsFileEditor.Core/Win32/NativeMethods.cs
@@ -31,4 +31,24 @@ public static partial class NativeMethods
         var result = DnsFlushResolverCache();
         Debug.WriteLine($"DnsFlushResolverCache: {result}");
     }
+
+    private const int AppModelErrorNoPackage = 15700;
+
+    [LibraryImport("kernel32.dll", EntryPoint = "GetCurrentPackageFullName")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    private static partial int GetCurrentPackageFullName(ref int packageFullNameLength, IntPtr packageFullName);
+
+    /// <summary>
+    /// True when the process is running from an installed MSIX/AppX package (has package identity),
+    /// false for the loose/portable build. Used to choose a version-independent launch path for the
+    /// taskbar Jump List: a packaged app's <see cref="Environment.ProcessPath"/> is version-stamped
+    /// (<c>…\WindowsApps\…_1.5.0.0_…\</c>) and goes stale on the next Store update.
+    /// </summary>
+    public static bool IsRunningPackaged()
+    {
+        var length = 0;
+        // Query with a null buffer: unpackaged returns APPMODEL_ERROR_NO_PACKAGE; packaged returns
+        // ERROR_INSUFFICIENT_BUFFER (or success), i.e. anything other than the no-package code.
+        return GetCurrentPackageFullName(ref length, IntPtr.Zero) != AppModelErrorNoPackage;
+    }
 }

--- a/HostsFileEditor.WinForm/AppxManifest.xml
+++ b/HostsFileEditor.WinForm/AppxManifest.xml
@@ -38,6 +38,16 @@
         Square44x44Logo="Assets\Square44x44Logo.png">
         <uap:SplashScreen Image="Assets\Square150x150Logo.png"/>
       </uap:VisualElements>
+      <Extensions>
+        <!-- Version-independent launch stub (%LOCALAPPDATA%\Microsoft\WindowsApps\HostsFileEditor.exe)
+             so the taskbar Jump List's persisted preset links survive a Store update instead of
+             pointing at the old version-stamped WindowsApps path (issue #106). -->
+        <uap5:Extension Category="windows.appExecutionAlias" Executable="HostsFileEditor.exe" EntryPoint="Windows.FullTrustApplication">
+          <uap5:AppExecutionAlias>
+            <uap5:ExecutionAlias Alias="HostsFileEditor.exe"/>
+          </uap5:AppExecutionAlias>
+        </uap5:Extension>
+      </Extensions>
     </Application>
     <!-- Console launcher (issue #2): a second app entry whose appExecutionAlias puts `hfe` on PATH so
          scripts can run `hfe -s Preset` etc. The entry is VISIBLE in the Start menu app list: hiding it

--- a/HostsFileEditor.WinForm/TaskbarJumpList.cs
+++ b/HostsFileEditor.WinForm/TaskbarJumpList.cs
@@ -1,5 +1,6 @@
 using Microsoft.WindowsAPICodePack.Shell;
 using Microsoft.WindowsAPICodePack.Taskbar;
+using HostsFileEditor.Win32;
 
 namespace HostsFileEditor;
 
@@ -17,6 +18,9 @@ internal static class TaskbarJumpList
 
     private const string PresetsCategory = "Presets";
 
+    /// <summary>The app-execution alias declared for the main app in the packaged manifest.</summary>
+    private const string AppExecutionAlias = "HostsFileEditor.exe";
+
     public static void Refresh()
     {
         if (!TaskbarManager.IsPlatformSupported)
@@ -24,11 +28,24 @@ internal static class TaskbarJumpList
             return;
         }
 
-        var exePath = Environment.ProcessPath;
-        if (string.IsNullOrEmpty(exePath))
+        var iconPath = Environment.ProcessPath;
+        if (string.IsNullOrEmpty(iconPath))
         {
             return;
         }
+
+        // Jump list links are persisted by the shell and must survive an app update. A packaged
+        // (Store) build's ProcessPath is version-stamped (…\WindowsApps\…_1.5.0.0_…\), so every
+        // update strands the old links with a dead target (issue #106). Launch via the app-execution
+        // alias stub instead — %LOCALAPPDATA%\Microsoft\WindowsApps\HostsFileEditor.exe — which the OS
+        // repoints to the current version and which passes our --open-archive args through. The loose
+        // build has no alias, so it keeps using ProcessPath. (The icon stays on ProcessPath; it's
+        // cosmetic and refreshed on each launch, so a stale icon after an update is harmless.)
+        var launchPath = NativeMethods.IsRunningPackaged()
+            ? Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "Microsoft", "WindowsApps", AppExecutionAlias)
+            : iconPath;
 
         try
         {
@@ -43,10 +60,10 @@ internal static class TaskbarJumpList
                 var category = new JumpListCustomCategory(PresetsCategory);
                 foreach (var archive in archives)
                 {
-                    category.AddJumpListItems(new JumpListLink(exePath, archive.FileName)
+                    category.AddJumpListItems(new JumpListLink(launchPath, archive.FileName)
                     {
                         Arguments = $"{OpenArchiveSwitch} \"{archive.FilePath}\"",
-                        IconReference = new IconReference(exePath, 0),
+                        IconReference = new IconReference(iconPath, 0),
                     });
                 }
 


### PR DESCRIPTION
**Priority: bug (non-blocker), Store-install only.** v1.5.1/v1.2.1 release-review follow-up (Jump List #10, classic).

## Problem (issue #106)
The classic Jump List used `Environment.ProcessPath` as each preset link's target. Under a Store/MSIX install that path is **version-stamped** (`…\WindowsApps\…_1.5.0.0_…\HostsFileEditor.exe`), so after a Store update the shell-persisted links point at the removed old package — clicking a preset silently does nothing until the app is next launched some other way (only `OnFomLoad` refreshes the list). Modern is immune (WinRT `JumpList` is package-identity-aware).

## Fix
- **Manifest:** declare a `windows.appExecutionAlias` for the **main** classic app (`HostsFileEditor.exe`) → a stable stub at `%LOCALAPPDATA%\Microsoft\WindowsApps\HostsFileEditor.exe` that the OS repoints to the current version and that passes `--open-archive` args through.
- **Code:** `NativeMethods.IsRunningPackaged()` (`GetCurrentPackageFullName`) detects the packaged build; `Refresh` targets the alias stub when packaged, and keeps `ProcessPath` for the loose/portable build. Icon stays on `ProcessPath` (cosmetic, refreshed each launch).

## ⚠️ Review notes
- **Manifest change → Store implications.** This adds a **second app-execution alias** (`HostsFileEditor.exe`, alongside the existing `hfe`) to the classic package, so `HostsFileEditor.exe` also lands on PATH. It's a normal *visible* app alias (no HeadlessAppBypass needed), but it's new Store-package surface for the next submission — worth a conscious sign-off.
- **Not locally testable.** The stale-link scenario only manifests across an actual Store package update. The loose build path (unchanged, uses ProcessPath) is what's exercised in dev.
- If you'd prefer to avoid the extra alias, the alternative is accepting the self-healing behavior (links work again after the next launch) and closing this as won't-fix.

## Tests
Core builds warnings-clean, 174 tests pass. `IsRunningPackaged` returns false in the loose build (dev/CI), preserving current behavior there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)