### PR TITLE
#108 Classic: don't point the hotkey-failure dialog at a dead path under MSIX

### DIFF
--- a/HostsFileEditor.WinForm/MainForm.cs
+++ b/HostsFileEditor.WinForm/MainForm.cs
@@ -3,6 +3,7 @@ using HostsFileEditor.Extensions;
 using HostsFileEditor.Properties;
 using HostsFileEditor.Utilities;
 using System.Configuration;
+using System.Runtime.InteropServices;
 using System.Text;
 
 namespace HostsFileEditor;
@@ -181,28 +182,63 @@ internal sealed partial class MainForm : Form
     /// </summary>
     private void ShowGlobalHotkeyFailedMessage()
     {
-        string configPath;
-        try
+        var message =
+            $"The global show/hide shortcut \"{_globalHotkeyFailedCombo}\" could not be registered — " +
+            "another application is probably already using it (or it is not a valid combination).\n\n" +
+            "The editor still works normally; only the global shortcut is unavailable — you can still " +
+            "show and hide the window from the tray icon.\n\n";
+
+        // Only the portable build can point the user at an editable user.config: under an MSIX (Store)
+        // install, %LocalAppData% writes are virtualized into the package's LocalCache, so the path
+        // ConfigurationManager reports is the UNVIRTUALIZED location where an edit has no effect
+        // (issue #108). Rather than send Store users to a dead path, give edition-appropriate guidance.
+        if (IsRunningPackaged())
         {
-            configPath = ConfigurationManager
-                .OpenExeConfiguration(ConfigurationUserLevel.PerUserRoamingAndLocal).FilePath;
+            message +=
+                "To change or disable the shortcut in the Store version, install the portable build " +
+                "(it keeps its settings in an editable file), or choose a different combination once " +
+                "the other application releases it.";
         }
-        catch (ConfigurationErrorsException)
+        else
         {
-            configPath = "the application's user.config file";
+            string configPath;
+            try
+            {
+                configPath = ConfigurationManager
+                    .OpenExeConfiguration(ConfigurationUserLevel.PerUserRoamingAndLocal).FilePath;
+            }
+            catch (ConfigurationErrorsException)
+            {
+                configPath = "the application's user.config file";
+            }
+
+            message +=
+                "To change or disable it, close the app and edit the GlobalShowHideHotkey value in:\n\n" +
+                $"{configPath}\n\n" +
+                "Examples:  \"Control, Shift, H\"  or  \"Ctrl+Alt+F8\".  Leave it blank to disable the shortcut.";
         }
 
         MessageBox.Show(
             this,
-            $"The global show/hide shortcut \"{_globalHotkeyFailedCombo}\" could not be registered — " +
-            "another application is probably already using it (or it is not a valid combination).\n\n" +
-            "The editor still works normally; only the global shortcut is unavailable.\n\n" +
-            "To change or disable it, close the app and edit the GlobalShowHideHotkey value in:\n\n" +
-            $"{configPath}\n\n" +
-            "Examples:  \"Control, Shift, H\"  or  \"Ctrl+Alt+F8\".  Leave it blank to disable the shortcut.",
+            message,
             "Global Shortcut Unavailable",
             MessageBoxButtons.OK,
             MessageBoxIcon.Information);
+    }
+
+    private const int AppModelErrorNoPackage = 15700;
+
+    [LibraryImport("kernel32.dll", EntryPoint = "GetCurrentPackageFullName")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    private static partial int GetCurrentPackageFullName(ref int packageFullNameLength, IntPtr packageFullName);
+
+    // True when running from an installed MSIX/AppX package (has package identity); false for the
+    // portable build. Used to tailor the hotkey-failure guidance, whose user.config path is only
+    // meaningful for the unvirtualized portable build.
+    private static bool IsRunningPackaged()
+    {
+        var length = 0;
+        return GetCurrentPackageFullName(ref length, IntPtr.Zero) != AppModelErrorNoPackage;
     }
 
     /// <inheritdoc />

--- a/HostsFileEditor.WinForm/MainForm.cs
+++ b/HostsFileEditor.WinForm/MainForm.cs
@@ -195,9 +195,8 @@ internal sealed partial class MainForm : Form
         if (IsRunningPackaged())
         {
             message +=
-                "To change or disable the shortcut in the Store version, install the portable build " +
-                "(it keeps its settings in an editable file), or choose a different combination once " +
-                "the other application releases it.";
+                "The Store version has no in-app setting to change or disable the shortcut yet. To " +
+                "customize it, install the portable build, which keeps its settings in an editable file.";
         }
         else
         {


### PR DESCRIPTION
**Priority: bug (non-blocker), Store-install + hotkey-conflict only.** v1.5.1/v1.2.1 release-review follow-up (hotkey #35 × MSIX).

## Problem (issue #108)
`ShowGlobalHotkeyFailedMessage` printed `ConfigurationManager.OpenExeConfiguration(...).FilePath` and told the user to edit it. Under an MSIX/Store install, `%LocalAppData%` writes are **virtualized** into `%LocalAppData%\Packages\…\LocalCache`, so the reported path is the *unvirtualized* location — a Store user following it finds nothing, or edits a file the packaged app never reads. Correct for the portable ZIP.

## Fix
Detect the packaged build (`GetCurrentPackageFullName`, a self-contained local P/Invoke — deliberately not touching `NativeMethods` so this doesn't collide with #106) and branch the guidance:
- **portable** → still shows the editable `user.config` path (correct there);
- **Store** → points to the portable build or to freeing the conflicting combination, instead of a dead path.

## Design note
The Store-build guidance is honest but limited — there's genuinely no in-app way to reconfigure the hotkey today. The real fix is an **in-app hotkey setting UI**, which would obsolete the file-editing instructions for both editions; I'd suggest that as a follow-up enhancement rather than trying to surface the fragile virtualized path. Happy to file it.

## Tests
Classic builds clean. `IsRunningPackaged` returns false in the portable/dev build, so that path (the common one) is unchanged.

## Validation note
Only reachable when the configured hotkey fails to register (another app owns Ctrl+Shift+H) AND the app is Store-installed. **To validate the portable path:** temporarily make the hotkey conflict (e.g. set it to a combo another app owns) in a portable build → dialog shows the real user.config path as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)