### PR TITLE
#105 Document the hfe alias behavior when both editions are installed

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -92,8 +92,8 @@ Run with no command and the app opens normally.
 
 > **Both editions installed?** The classic and modern Store apps each register the same `hfe` alias.
 > Windows treats the duplicate as a conflict, so **which edition owns `hfe` isn't guaranteed** &mdash;
-> pick the one you want under *Settings &rarr; Apps &rarr; App execution aliases* (Windows 11:
-> *Advanced app settings &rarr; App execution aliases*). Each Store package also keeps its **own
+> pick the one you want under *Settings &rarr; Apps &rarr; Apps &amp; features &rarr; App execution
+> aliases* (Windows 11: *Advanced app settings &rarr; App execution aliases*). Each Store package also keeps its **own
 > isolated app data**, so `hfe list` reflects whichever edition the alias points at, which may differ
 > from the other edition's window. If you script with `hfe`, install just the edition you script
 > against &mdash; or call that edition's `hfe.exe` by full path. Portable (zip) builds are unpackaged

--- a/Readme.md
+++ b/Readme.md
@@ -90,13 +90,15 @@ Two executables run the same commands:
 
 Run with no command and the app opens normally.
 
-> **Both editions installed?** The classic and modern Store apps each register the same `hfe` alias,
-> and Windows resolves it to whichever edition was **installed last** (you can switch which one owns it
-> under *Settings → Apps → Advanced app settings → App execution aliases*). They also keep **separate**
-> preset/archive stores (each Store package has its own isolated app data), so `hfe list` reflects the
-> edition the alias points at, which may differ from the other edition's window. If you script with
-> `hfe`, install just the edition you script against — or call that edition's `hfe.exe` by full path.
-> The **portable** build shares one data folder, so this only affects Store installs of both editions.
+> **Both editions installed?** The classic and modern Store apps each register the same `hfe` alias.
+> Windows treats the duplicate as a conflict, so **which edition owns `hfe` isn't guaranteed** &mdash;
+> pick the one you want under *Settings &rarr; Apps &rarr; App execution aliases* (Windows 11:
+> *Advanced app settings &rarr; App execution aliases*). Each Store package also keeps its **own
+> isolated app data**, so `hfe list` reflects whichever edition the alias points at, which may differ
+> from the other edition's window. If you script with `hfe`, install just the edition you script
+> against &mdash; or call that edition's `hfe.exe` by full path. Portable (zip) builds are unpackaged
+> and don't register the alias at all, so this is a Store-install-only concern (and only the classic
+> edition ships a portable build).
 
 ### Permissions
 

--- a/Readme.md
+++ b/Readme.md
@@ -90,6 +90,14 @@ Two executables run the same commands:
 
 Run with no command and the app opens normally.
 
+> **Both editions installed?** The classic and modern Store apps each register the same `hfe` alias,
+> and Windows resolves it to whichever edition was **installed last** (you can switch which one owns it
+> under *Settings → Apps → Advanced app settings → App execution aliases*). They also keep **separate**
+> preset/archive stores (each Store package has its own isolated app data), so `hfe list` reflects the
+> edition the alias points at, which may differ from the other edition's window. If you script with
+> `hfe`, install just the edition you script against — or call that edition's `hfe.exe` by full path.
+> The **portable** build shares one data folder, so this only affects Store installs of both editions.
+
 ### Permissions
 
 Commands that change the hosts file need administrator rights, exactly like saving in the GUI: run


### PR DESCRIPTION
**Priority: docs / design (non-blocker), both-editions-installed only.** v1.5.1/v1.2.1 release-review follow-up (CLI #2 packaging).

## Problem (issue #105)
Both Store packages declare the same `hfe` execution alias. With **both** editions installed: (1) Windows resolves `hfe` to whichever was **installed last** (switchable only in Settings → App execution aliases); (2) MSIX virtualization gives each package its **own** `%LocalAppData%\HostsFileEditor`, so the alias-launched `hfe` can enumerate a different preset store than the GUI in front of you (`hfe list` shows presets the visible editor doesn't, or "not found" for one it does).

## Why documentation rather than a code change
The realistic options and their costs:
1. **Distinct aliases per edition** — e.g. keep `hfe` for one, give the other `hfec`. But `hfe` is the command we just shipped and documented for *both* editions on the Store; renaming one breaks that and needs a fresh submission, and it's arbitrary which edition "loses" `hfe`.
2. **Share one un-virtualized data store** across both packages (so the split disappears) — a real behavior change with its own cross-edition-state implications, and risky to land blind.
3. **Document it** (this PR) — the editions are separate apps by design, most users install one, and the portable build already shares a folder. Lowest-risk, honest.

I went with (3): the Command line section now explains the last-installed-wins alias, the separate Store data stores, and to install a single edition when scripting. **If you'd prefer (1) or (2)**, I'm happy to implement it — it's a deliberate product call, so I didn't want to change the shipped alias/behavior unilaterally.

## Also worth confirming
Within a *single* installed edition, its `hfe` and its GUI share the same package identity, so they should see the same presets — worth a quick manual check on a Store install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)