### PR TITLE
#100 Re-sync the enable/disable toggle on window activation (CLI/GUI)

### DIFF
--- a/HostsFileEditor.WinForm/MainForm.cs
+++ b/HostsFileEditor.WinForm/MainForm.cs
@@ -218,6 +218,27 @@ internal sealed partial class MainForm : Form
     }
 
     /// <inheritdoc />
+    protected override void OnActivated(EventArgs e)
+    {
+        base.OnActivated(e);
+
+        // The CLI (or another process) may have enabled/disabled the hosts file while our window was in
+        // the background. Re-sync the toggle from the file system whenever the window comes forward, so
+        // it never asserts a stale state — otherwise clicking "Disable" while it wrongly showed enabled
+        // would do the opposite of what's shown (#100). HostsFile.IsEnabled is a cheap File.Exists that
+        // never forces the HostsFile lazy, so this is safe even mid-load; only skip the failed-load exit.
+        if (_loadFailed)
+        {
+            return;
+        }
+
+        var disabledNow = !HostsFile.IsEnabled;
+        menuDisable.Checked = disabledNow;
+        buttonDisable.Checked = disabledNow;
+        menuContextDisable.Checked = disabledNow;
+    }
+
+    /// <inheritdoc />
     protected override void WndProc(ref Message message)
     {
         if (message.Msg == ProgramSingleInstance.WmShowFirstInstance)

--- a/HostsFileEditor.WinForm/MainForm.cs
+++ b/HostsFileEditor.WinForm/MainForm.cs
@@ -236,6 +236,12 @@ internal sealed partial class MainForm : Form
         menuDisable.Checked = disabledNow;
         buttonDisable.Checked = disabledNow;
         menuContextDisable.Checked = disabledNow;
+
+        // Also refresh the tray icon (enabled vs disabled glyph). The primary #100 scenario is a
+        // tray-resident app that a CLI `hfe disable/enable` toggled; without this, restoring from the
+        // tray would fix the menu toggles but leave the tray icon showing the stale state. Matches
+        // OnDisableHostsClick and OnFomLoad, which both update the toggles and the icon together.
+        UpdateNotifyIcon();
     }
 
     /// <inheritdoc />

--- a/HostsFileEditor.WinUI/MainWindow.xaml.cs
+++ b/HostsFileEditor.WinUI/MainWindow.xaml.cs
@@ -892,7 +892,17 @@ public sealed partial class MainWindow : Window, INotifyPropertyChanged
 
         Activated += (s, e) =>
         {
-            _backdropConfiguration?.IsInputActive = e.WindowActivationState != WindowActivationState.Deactivated;
+            var active = e.WindowActivationState != WindowActivationState.Deactivated;
+            _backdropConfiguration?.IsInputActive = active;
+
+            // Re-read the enabled/disabled state from the file system when the window comes forward:
+            // the CLI (or another process) may have toggled the hosts file while we were in the
+            // background, and the toggle binding would otherwise assert a stale state (#100).
+            // IsDisabledHosts is a cheap File.Exists that never forces the HostsFile lazy, so it's safe.
+            if (active)
+            {
+                OnPropertyChanged(nameof(IsDisabledHosts));
+            }
         };
 
         Closed += (s, e) =>


### PR DESCRIPTION
**Priority: enhancement (non-blocker).** v1.5.1/v1.2.1 release-review follow-up.

## Problem (issue #100)
The CLI runs in its own process and doesn't signal an open GUI. So `hfe enable`/`disable` while a GUI window is open left the GUI's Disable toggle showing a **stale** state — and because the click handler reads the *live* `HostsFile.IsEnabled`, clicking "Disable" while it wrongly showed enabled executed the opposite of what was displayed (the most actively misleading part of the review finding).

## Fix (the safe, high-value slice)
Re-read `HostsFile.IsEnabled` — a cheap `File.Exists` that never forces the `HostsFile` lazy — whenever the window is **activated**, and update the toggle:
- **classic** — an `OnActivated` override syncs the menu / toolbar / context `Disable` checkboxes;
- **modern** — its existing `Activated` handler raises `PropertyChanged` for the bound `IsDisabledHosts`.

So alt-tabbing back to the editor after a CLI toggle shows the correct state.

## Scope / deliberately out of scope
This addresses the misleading toggle only. The review's other two points — GUI **Save** recreating a live hosts file after a CLI disable, and `apply`/`import` being overwritten by a stale GUI Save (**last-writer-wins**) — are a larger change (a save-time on-disk timestamp check with an overwrite confirm, and/or a `FileSystemWatcher` offering reload). I left those as a follow-up rather than reworking Save semantics here; the README already documents the last-writer behavior and F5-to-refresh. Happy to take the bigger piece on if you want it.

## Validation note
**To validate (either edition):** open the editor, run `hfe disable` (or `enable`) in a console, then click back to the window — the Disable toggle should flip to match the file's actual state, and clicking it does the expected thing (not the reverse).

🤖 Generated with [Claude Code](https://claude.com/claude-code)