### PR TITLE
Release: classic 1.5.1 / modern 1.2.1 — patch (review follow-ups)

### DIFF
--- a/HostsFileEditor.WinForm/HostsFileEditor.WinForm.csproj
+++ b/HostsFileEditor.WinForm/HostsFileEditor.WinForm.csproj
@@ -22,7 +22,7 @@
     <!-- Single version source for this app: drives AssemblyVersion, FileVersion, the exe's
          ProductVersion resource, and (stamped in Directory.Build.targets) the MSIX manifest
          Identity/@Version. ProductVersion is not an SDK-recognized property and was ignored. -->
-    <Version>1.5.0.0</Version>
+    <Version>1.5.1.0</Version>
     <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
     <!-- Native AOT isn't working yet with WinForms, specifically Binding is explicitly not supported throwing NotSupportedException -->
     <!--<PublishAot>true</PublishAot>-->

--- a/HostsFileEditor.WinUI/HostsFileEditor.WinUI.csproj
+++ b/HostsFileEditor.WinUI/HostsFileEditor.WinUI.csproj
@@ -7,7 +7,7 @@
     <!-- Single version source for this app (the modern UI ships as its own version stream,
          separate from classic). Drives AssemblyVersion/FileVersion/ProductVersion and, stamped
          in Directory.Build.targets, the MSIX manifest Identity/@Version. -->
-    <Version>1.2.0.0</Version>
+    <Version>1.2.1.0</Version>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platform Condition="'$(Platform)' == ''">x64</Platform>
     <Platforms>x64;arm64</Platforms>

--- a/Readme.md
+++ b/Readme.md
@@ -119,12 +119,14 @@ Installs and updates automatically, with no separate download:
  * [Hosts File Editor (modern)](https://apps.microsoft.com/detail/9NBQWCDXGF9R) &mdash; the new WinUI edition
  * [Hosts File Editor (classic)](https://apps.microsoft.com/detail/9NF73PSPK332) &mdash; the classic WinForms edition
 
-### Portable &mdash; v1.5.0
+### Portable &mdash; v1.5.1
 
 The **classic edition** rebuilt on .NET 10: fully self-contained (no runtime to install), runs as a standard user, and elevates on demand (a single UAC prompt) only when you save changes to the hosts file. Binaries are signed. Download directly from [GitHub Releases](https://github.com/scottlerch/HostsFileEditor/releases):
 
- * [Download v1.5.0 portable &mdash; x64](https://github.com/scottlerch/HostsFileEditor/releases/download/v1.5.0/HostsFileEditor-1.5.0-x64.zip)
- * [Download v1.5.0 portable &mdash; ARM64](https://github.com/scottlerch/HostsFileEditor/releases/download/v1.5.0/HostsFileEditor-1.5.0-arm64.zip)
+ * [Download v1.5.1 portable &mdash; x64](https://github.com/scottlerch/HostsFileEditor/releases/download/v1.5.1/HostsFileEditor-1.5.1-x64.zip)
+ * [Download v1.5.1 portable &mdash; ARM64](https://github.com/scottlerch/HostsFileEditor/releases/download/v1.5.1/HostsFileEditor-1.5.1-arm64.zip)
+
+_What's new in v1.5.1 (classic) / v1.2.1 (modern):_ a **quality &amp; robustness patch** following the v1.5.0 / v1.2.0 feature release. The command line no longer risks **losing a saved (disabled) hosts configuration** on a repeated `disable`, and reports **ambiguous preset names** instead of guessing. The classic edition now **carries your settings forward across updates** (window size, auto-ping, the global shortcut) instead of resetting them, keeps the tray icon and toggle in sync after a command-line change, and its taskbar Jump List survives Store updates. The modern edition fixes a rare **crash** when a background merge/import overlapped a ping, and a Jump List preset clicked during a reload now opens. Plus smaller polish: paste-while-sorted appends predictably, merges don't ping discarded duplicates, and clearer messages. See the [full release notes](https://github.com/scottlerch/HostsFileEditor/releases/tag/v1.5.1).
 
 _What's new in v1.5.0 (classic) / v1.2.0 (modern):_ a **feature release**. A full **[command line](#command-line)** in both editions plus a new `hfe.exe` console launcher &mdash; switch presets, enable/disable, import, and merge from scripts (Store installs put `hfe` on `PATH`). A taskbar **Jump List**: right-click the app icon to open any preset directly. **File &rarr; Merge** combines another hosts file into the current one, skipping duplicates (undoable). The modern edition gains **Sort options** next to the filter, and the **IP column now sorts numerically** in both editions (`8.8.8.8` before `10.0.0.2` before `10.0.0.10`, IPv6 after IPv4). **Auto-ping** shows a status-bar progress indicator while pings are in flight, flags per-entry failures (modern gets an error badge with tooltip), and pings immediately when enabled. The classic edition adds a **global shortcut** (default `Ctrl+Shift+H`, configurable) to hide/restore from the tray, its text **filter is now case-insensitive** to match modern, the parser validates IPs strictly at parse time, and the portable zip dropped ~9 MB of unused libraries. See the [full release notes](https://github.com/scottlerch/HostsFileEditor/releases/tag/v1.5.0).
 

--- a/publish-store.ps1
+++ b/publish-store.ps1
@@ -65,20 +65,18 @@ $storeDir = Join-Path $PSScriptRoot 'artifacts\store'
 # ---- Per-release "What's new" copy (edit each release) ----
 $notes = @{
     classic = @'
-Feature update (v1.5.0):
-- Command line for scripts: switch presets, enable/disable, import, and merge (hfe on PATH; run "hfe help").
-- Taskbar Jump List: right-click the app icon to open any saved preset directly.
-- File > Merge combines another hosts file into the current one, skipping duplicates (undoable).
-- Global shortcut (default Ctrl+Shift+H, configurable) hides/restores the window from the tray.
-- IP column now sorts numerically; text filter is now case-insensitive; auto-ping shows a progress indicator and flags failed entries.
+Quality and reliability update (v1.5.1):
+- The command line no longer risks losing a saved (disabled) hosts configuration on a repeated disable, and reports ambiguous preset names instead of guessing.
+- Your settings (window size, auto-ping, the global shortcut) now carry forward across updates instead of resetting.
+- The tray icon and Disable toggle stay in sync after a command-line change, and the taskbar Jump List keeps working after updates.
+- Smaller polish: merges no longer ping skipped duplicates, and clearer messages.
 '@
     modern = @'
-Feature update (v1.2.0):
-- Command line for scripts: switch presets, enable/disable, import, and merge (hfe on PATH; run "hfe help").
-- Taskbar Jump List: right-click the app icon to open any saved preset directly.
-- File > Merge combines another hosts file into the current one, skipping duplicates (undoable).
-- New Sort options next to the filter; the IP column sorts numerically.
-- Auto-ping shows a progress indicator and marks failed entries with an error badge.
+Quality and reliability update (v1.2.1):
+- Fixed a rare crash when a background merge/import overlapped a ping.
+- A taskbar Jump List preset clicked while the app is reloading now opens correctly.
+- The command line no longer risks losing a saved (disabled) hosts configuration on a repeated disable, and reports ambiguous preset names instead of guessing.
+- Pasting while a sort is active now appends predictably; ping status stays accurate after editing an address.
 '@
 }
 


### PR DESCRIPTION
Patch release **classic 1.5.1 / modern 1.2.1** — the v1.5.0/v1.2.0 release-review follow-up fixes (#96–#108), all merged.

## In this PR
- **Version bump**: classic `1.5.0.0 → 1.5.1.0`, modern `1.2.0.0 → 1.2.1.0`.
- **Readme**: v1.5.1 Download links + a "quality & robustness patch" what's-new entry.

## What's fixed (merged #110–#123)
| Fix | Issue |
|---|---|
| CLI `disable` no longer destroys a differing saved `hosts.disabled` (data-loss guard) | #99 |
| Modern: crash race when a background merge/import overlaps a ping | #103 |
| Ping-state consistency — stale result no longer marks the edited IP failed; clone carries the flag | #96 |
| CLI reports ambiguous preset stems instead of guessing by FS order | #98 |
| Classic: user settings survive version bumps (`Settings.Upgrade`) | #107 |
| Merge no longer pings discarded duplicates | #97 |
| Modern: Jump List preset clicked during a reload now opens | #101 |
| Classic: Jump List mid-load no longer blocks the UI thread | #102 |
| Modern: paste-while-sorted appends at file end (defined position) | #104 |
| Classic: Jump List uses a version-independent alias when packaged | #106 |
| Classic: hotkey-failure dialog doesn't point at a dead path under MSIX | #108 |
| Docs: `hfe` alias behavior with both editions installed | #105 |
| Re-sync the enable/disable toggle (+ classic tray icon) on window activation | #100 |

## Verification
- Full Core suite green (**192 tests**, +18 from the fixes' new coverage).
- Two rounds of adversarial code review per PR; all findings addressed or documented.
- Signed Release publishes of both editions built and smoke-tested (the #99 CLI guard fires end-to-end; both `hfe.exe` run; both GUIs launch; classic WPF-native strip intact; MSIX versions stamped 1.5.1.0 / 1.2.1.0).

## Pre-submission checklist (Store + GitHub release)
- [ ] `.\build-all.ps1 -Sign` — the current `artifacts\` are **sideload test packages** (test cert/publisher); rebuild clean for all four flavor/arch combos.
- [ ] arm64 smoke test.
- [ ] Store submission via `publish-store.ps1` (update the `$notes` block to the 1.5.1/1.2.1 copy first).
- [ ] Tag `v1.5.1`, upload `HostsFileEditor-1.5.1-<arch>.zip`.
- [ ] Close milestone **v1.5.1 / v1.2.1 — patch (release-review follow-ups)** (all 13 issues resolved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
