### PR TITLE
#131 Add the missing InvalidHostnames resource key (blank hostname error)

### DIFF
--- a/HostsFileEditor.Core.Tests/HostsEntryTests.cs
+++ b/HostsFileEditor.Core.Tests/HostsEntryTests.cs
@@ -81,6 +81,20 @@ public class HostsEntryTests
         entry.Valid.ShouldBeFalse();
     }
 
+    // Regression for #131: Resources.InvalidHostnames had no matching key in Core's Resources.resx,
+    // so it resolved to null and SetError(null) cleared the error — an invalid hostname surfaced a
+    // BLANK IDataErrorInfo message (rather than "Invalid host names") in both editions.
+    [TestMethod]
+    public void Invalid_Hostname_HasNonBlankErrorMessage()
+    {
+        var entry = new HostsEntry("127.0.0.1 goodhost");
+        entry.HostNames = "bad@host"; // invalid character
+
+        entry.Valid.ShouldBeFalse();
+        entry["HostNames"].ShouldNotBeNullOrEmpty();
+        entry["HostNames"].ShouldBe(HostsFileEditor.Properties.Resources.InvalidHostnames);
+    }
+
     [TestMethod]
     public void ToString_ReturnsExpected()
     {

--- a/HostsFileEditor.Core/Properties/Resources.resx
+++ b/HostsFileEditor.Core/Properties/Resources.resx
@@ -68,6 +68,9 @@
   <data name="InvalidHostEntries" xml:space="preserve">
     <value>Invalid Host Entries</value>
   </data>
+  <data name="InvalidHostnames" xml:space="preserve">
+    <value>Invalid host names</value>
+  </data>
   <data name="LoseChangesDialogCaption" xml:space="preserve">
     <value>Hosts File Editor Question</value>
   </data>


### PR DESCRIPTION
**User-facing bug fix**, split out of the larger CI/coverage PR #132 so it can land on its own (per your request). No release needed on its own, but this is a real visible bug in shipped v1.5.1/v1.2.1.

## Problem (issue #131)
The strongly-typed `Resources.InvalidHostnames` getter exists, but Core's `Resources.resx` had **no matching `<data name="InvalidHostnames">` entry** (it has `InvalidHostEntries` and `InvalidIPAddress`, just not this one), so the getter resolved to **null**. `HostsEntry.ValidateHostnames` does:
```csharp
SetError(nameof(HostNames), !_hostnamesValid ? Resources.InvalidHostnames : null);
```
and `SetError(null)` clears the error — so an **invalid hostname surfaced a blank validation message** in both the classic (WinForms) and modern (WinUI) editions, instead of "Invalid host names".

## Fix
- Add the `InvalidHostnames` key (`"Invalid host names"`, matching the WinForm resource and PR #132's value) to `HostsFileEditor.Core/Properties/Resources.resx`.
- Regression test: an invalid hostname now yields a non-empty `IDataErrorInfo` message equal to `Resources.InvalidHostnames`.

Full Core suite green (193). 

## Relationship to PR #132
This is the same one-line resx fix (+ an equivalent regression test) that's bundled inside the larger **CI + test-coverage PR #132**. Landing it here lets the visible bug ship independently; when #132 is later reviewed/rebased, its now-redundant `InvalidHostnames` resx hunk (and matching test) can be dropped — the values are identical, so reconciliation is trivial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)