### PR TITLE
CI: bump actions to Node 24 majors (silence Node 20 deprecation)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # Installs the exact SDK pinned in global.json (10.0.301, rollForward latestFeature).
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           global-json-file: global.json
 
@@ -93,7 +93,7 @@ jobs:
 
       - name: Upload test results and coverage
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results-${{ matrix.arch }}
           path: |


### PR DESCRIPTION
Bumps the three GitHub-provided actions off the deprecated Node 20 runtime:

- `actions/checkout` v4 → **v5**
- `actions/setup-dotnet` v4 → **v5**
- `actions/upload-artifact` v4 → **v7**

All current majors run on Node 24, which silences the *"Node.js 20 is deprecated"* annotation on every CI run. No workflow logic changes — this PR's own CI run validates the bumped actions on both x64 and ARM64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)