### PR TITLE
Release: classic 1.5.2 / modern 1.2.2 — patch (large-list clip fix + hostname validation)

### DIFF
--- a/HostsFileEditor.WinForm/HostsFileEditor.WinForm.csproj
+++ b/HostsFileEditor.WinForm/HostsFileEditor.WinForm.csproj
@@ -22,7 +22,7 @@
     <!-- Single version source for this app: drives AssemblyVersion, FileVersion, the exe's
          ProductVersion resource, and (stamped in Directory.Build.targets) the MSIX manifest
          Identity/@Version. ProductVersion is not an SDK-recognized property and was ignored. -->
-    <Version>1.5.1.0</Version>
+    <Version>1.5.2.0</Version>
     <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
     <!-- Native AOT isn't working yet with WinForms, specifically Binding is explicitly not supported throwing NotSupportedException -->
     <!--<PublishAot>true</PublishAot>-->

--- a/HostsFileEditor.WinUI/HostsFileEditor.WinUI.csproj
+++ b/HostsFileEditor.WinUI/HostsFileEditor.WinUI.csproj
@@ -7,7 +7,7 @@
     <!-- Single version source for this app (the modern UI ships as its own version stream,
          separate from classic). Drives AssemblyVersion/FileVersion/ProductVersion and, stamped
          in Directory.Build.targets, the MSIX manifest Identity/@Version. -->
-    <Version>1.2.1.0</Version>
+    <Version>1.2.2.0</Version>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Platform Condition="'$(Platform)' == ''">x64</Platform>
     <Platforms>x64;arm64</Platforms>

--- a/Readme.md
+++ b/Readme.md
@@ -119,12 +119,14 @@ Installs and updates automatically, with no separate download:
  * [Hosts File Editor (modern)](https://apps.microsoft.com/detail/9NBQWCDXGF9R) &mdash; the new WinUI edition
  * [Hosts File Editor (classic)](https://apps.microsoft.com/detail/9NF73PSPK332) &mdash; the classic WinForms edition
 
-### Portable &mdash; v1.5.1
+### Portable &mdash; v1.5.2
 
 The **classic edition** rebuilt on .NET 10: fully self-contained (no runtime to install), runs as a standard user, and elevates on demand (a single UAC prompt) only when you save changes to the hosts file. Binaries are signed. Download directly from [GitHub Releases](https://github.com/scottlerch/HostsFileEditor/releases):
 
- * [Download v1.5.1 portable &mdash; x64](https://github.com/scottlerch/HostsFileEditor/releases/download/v1.5.1/HostsFileEditor-1.5.1-x64.zip)
- * [Download v1.5.1 portable &mdash; ARM64](https://github.com/scottlerch/HostsFileEditor/releases/download/v1.5.1/HostsFileEditor-1.5.1-arm64.zip)
+ * [Download v1.5.2 portable &mdash; x64](https://github.com/scottlerch/HostsFileEditor/releases/download/v1.5.2/HostsFileEditor-1.5.2-x64.zip)
+ * [Download v1.5.2 portable &mdash; ARM64](https://github.com/scottlerch/HostsFileEditor/releases/download/v1.5.2/HostsFileEditor-1.5.2-arm64.zip)
+
+_What's new in v1.5.2 (classic) / v1.2.2 (modern):_ a small **quality patch**. The modern edition no longer lets list rows **bleed over the status bar** on very large hosts files (100K+ entries) &mdash; a WinUI rendering bug that spilled the bottom rows past the list is now held off at the source, so the status bar stays clean at any list size. Both editions now show a clear **"Invalid host names"** validation message for a bad host name instead of a blank one. See the [full release notes](https://github.com/scottlerch/HostsFileEditor/releases/tag/v1.5.2).
 
 _What's new in v1.5.1 (classic) / v1.2.1 (modern):_ a **quality &amp; robustness patch** following the v1.5.0 / v1.2.0 feature release. The command line no longer risks **losing a saved (disabled) hosts configuration** on a repeated `disable`, and reports **ambiguous preset names** instead of guessing. The classic edition now **carries your settings forward across updates** (window size, auto-ping, the global shortcut) instead of resetting them, keeps the tray icon and toggle in sync after a command-line change, and its taskbar Jump List survives Store updates. The modern edition fixes a rare **crash** when a background merge/import overlapped a ping, and a Jump List preset clicked during a reload now opens. Plus smaller polish: paste-while-sorted appends predictably, merges don't ping discarded duplicates, and clearer messages. See the [full release notes](https://github.com/scottlerch/HostsFileEditor/releases/tag/v1.5.1).
 

--- a/publish-store.ps1
+++ b/publish-store.ps1
@@ -65,18 +65,13 @@ $storeDir = Join-Path $PSScriptRoot 'artifacts\store'
 # ---- Per-release "What's new" copy (edit each release) ----
 $notes = @{
     classic = @'
-Quality and reliability update (v1.5.1):
-- The command line no longer risks losing a saved (disabled) hosts configuration on a repeated disable, and reports ambiguous preset names instead of guessing.
-- Your settings (window size, auto-ping, the global shortcut) now carry forward across updates instead of resetting.
-- The tray icon and Disable toggle stay in sync after a command-line change, and the taskbar Jump List keeps working after updates.
-- Smaller polish: merges no longer ping skipped duplicates, and clearer messages.
+Quality update (v1.5.2):
+- An invalid host name now shows a clear "Invalid host names" validation message instead of a blank one.
 '@
     modern = @'
-Quality and reliability update (v1.2.1):
-- Fixed a rare crash when a background merge/import overlapped a ping.
-- A taskbar Jump List preset clicked while the app is reloading now opens correctly.
-- The command line no longer risks losing a saved (disabled) hosts configuration on a repeated disable, and reports ambiguous preset names instead of guessing.
-- Pasting while a sort is active now appends predictably; ping status stays accurate after editing an address.
+Quality update (v1.2.2):
+- List rows no longer bleed over the status bar on very large hosts files (100K+ entries) - the bottom rows stay clipped inside the list at any size.
+- An invalid host name now shows a clear "Invalid host names" validation message instead of a blank one.
 '@
 }
 


### PR DESCRIPTION
Patch release following v1.5.1 / v1.2.1.

## What's in it (changes since v1.5.1)

- **Modern (#79):** list rows no longer bleed over the status bar on very large
  hosts files (100K+ entries). The WinUI raster clip-escape bug that spilled the
  bottom rows past the list is fixed by giving the `ListView` a non-zero
  `CornerRadius` (which re-establishes the composition clip); the old status-bar
  backplate is removed. Verified on a ~400K-entry file.
- **Both editions (#131):** an invalid host name now surfaces an
  **"Invalid host names"** validation message instead of a blank one — the
  `InvalidHostnames` key was missing from Core's shared `Resources.resx`.

(Also since v1.5.1, but not customer-facing: CI across x64/ARM64, Core coverage to
~88%, a classic refactor to the shared `IsRunningPackaged()` helper (#128).)

## Release chores (mirrors #124)

- Bump `Version`: **1.5.2.0** (classic) / **1.2.2.0** (modern).
- Refresh the Readme Download section — v1.5.2 links + a new what's-new paragraph.
- Update the `publish-store.ps1` "What's new" copy for 1.5.2 / 1.2.2.

Only version/notes files change — no product code in this PR (the fixes already
landed in #135, #132/#133).

## After merge

- Tag `v1.5.2` + GitHub release (draft prepared).
- `build-all.ps1 -Sign` → attach `HostsFileEditor-1.5.2-x64.zip` / `-arm64.zip` to
  the release, then publish it.
- `publish-store.ps1` → push both Store submissions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
