### PR TITLE
Pin NativeAOT ILCompiler to 10.0.10 to match the installed .NET 10 runtime

### DIFF
--- a/HostsFileEditor.Cli/HostsFileEditor.Cli.csproj
+++ b/HostsFileEditor.Cli/HostsFileEditor.Cli.csproj
@@ -18,4 +18,9 @@
   <ItemGroup>
     <ProjectReference Include="..\HostsFileEditor.Core\HostsFileEditor.Core.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <!-- Pin the NativeAOT ILCompiler to match the installed .NET 10 runtime (10.0.10); see the
+         same note in HostsFileEditor.Elevate.csproj. Remove once the SDK default catches up. -->
+    <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="10.0.10" />
+  </ItemGroup>
 </Project>

--- a/HostsFileEditor.Elevate/HostsFileEditor.Elevate.csproj
+++ b/HostsFileEditor.Elevate/HostsFileEditor.Elevate.csproj
@@ -18,4 +18,12 @@
     <PublishAot>true</PublishAot>
     <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
   </PropertyGroup>
+  <ItemGroup>
+    <!-- Pin the NativeAOT ILCompiler to match the installed .NET 10 runtime (10.0.10). The .NET SDK
+         10.0.302 still defaults the AOT compiler to 10.0.9, which conflicts with the newer 10.0.10
+         self-contained runtime pack ("Overriding System.Private.CoreLib.dll with a newer version is
+         not supported"). Aligning the compiler up to the runtime fixes AOT publish. Bump alongside
+         the runtime; remove once the SDK default catches up. -->
+    <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="10.0.10" />
+  </ItemGroup>
 </Project>

--- a/HostsFileEditor.WinUI/HostsFileEditor.WinUI.csproj
+++ b/HostsFileEditor.WinUI/HostsFileEditor.WinUI.csproj
@@ -61,6 +61,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.2.0" />
+    <!-- Pin the NativeAOT ILCompiler to match the installed .NET 10 runtime (10.0.10); see the same
+         note in HostsFileEditor.Elevate.csproj. The SDK 10.0.302 default (10.0.9) conflicts with the
+         newer 10.0.10 self-contained runtime pack. Remove once the SDK default catches up. -->
+    <PackageReference Include="Microsoft.DotNet.ILCompiler" Version="10.0.10" />
     <PackageReference Include="H.NotifyIcon.WinUI" Version="2.4.1" />
     <PackageReference Include="System.Resources.Extensions" Version="10.0.9" />
     <!-- Taskbar Jump List (issue #10) uses the WinRT Windows.UI.StartScreen.JumpList API — packaged-


### PR DESCRIPTION
## Problem

Release builds (`dotnet publish` / `build-all.ps1 -Sign`) fail during NativeAOT compilation:

```
error : Overriding System.Private.CoreLib.dll with a newer version is not supported.
Attempted to use ...runtime.win-x64\10.0.10\...\System.Private.CoreLib.dll
instead of ...runtime.nativeaot.win-x64\10.0.9\...\System.Private.CoreLib.dll
```

The .NET SDK 10.0.302 (the latest available) still defaults the NativeAOT compiler to **10.0.9**, but the self-contained runtime pack now resolves to the newer **10.0.10** servicing runtime. AOT requires the two to match, so every AOT project (`Elevate`, `Cli`, `WinUI`) fails to publish.

The .NET SDK and Windows App SDK are both already at their latest (`10.0.302` / `2.2.0`); this is purely the AOT compiler default lagging the runtime.

## Fix

Pin `Microsoft.DotNet.ILCompiler` to **10.0.10** in the three AOT projects, aligning the compiler up to the runtime.

- Only affects `dotnet publish` (release/AOT builds). CI runs `dotnet build` + `dotnet test`, which never invoke ILC, so the reference is inert in CI.
- Verified: `Elevate`, `Cli`, and `WinUI` all publish clean (x64) after the change.
- Bump alongside the runtime; remove once the SDK default catches up (noted in the csproj comments).

Needed to produce the signed **v1.5.2 / v1.2.2** release artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
